### PR TITLE
OpenFF DANCE 1 eMolecules t142 v1.0 - tracking

### DIFF
--- a/submissions/2020-06-01-DANCE-1-eMolecules-t142-selected/.gitignore
+++ b/submissions/2020-06-01-DANCE-1-eMolecules-t142-selected/.gitignore
@@ -1,9 +1,0 @@
-# Editor files
-.*.swp
-
-# Output files -- only `t142_selected.smi` (from DANCE) and
-# `optimization_inputs.json.gz` should be included.
-*.smi
-*.sdf
-*.txt
-*.json

--- a/submissions/2020-06-01-DANCE-1-eMolecules-t142-selected/dataset.json
+++ b/submissions/2020-06-01-DANCE-1-eMolecules-t142-selected/dataset.json
@@ -1,0 +1,4 @@
+{
+    "dataset_name": "OpenFF DANCE 1 eMolecules t142 v1.0",
+    "dataset_type": "TorsionDriveDataset"
+}


### PR DESCRIPTION
This PR plugs submission #102 into our [lifeycle](https://github.com/openforcefield/qca-dataset-submission/blob/master/LIFECYCLE.md) automation.

- [x] Created a new folder in the submissions directory containing the dataset
- [x] Added README.md describing the dataset see [here](https://github.com/openforcefield/qca-dataset-submission/tree/master/submissions/2020-03-26-OpenFF-Gen-2-Torsion-Set-6-supplemental-2) for examples
- [ ] All files used to produce the dataset are included with a description
- [ ] Dataset follows the QCSubmit schema defined for [Datasets](https://github.com/openforcefield/qcsubmit/blob/56680a7d3298b5d8962edcb840b0fdb34558c053/qcsubmit/datasets.py#L340), [OptimizationDatasets](https://github.com/openforcefield/qcsubmit/blob/56680a7d3298b5d8962edcb840b0fdb34558c053/qcsubmit/datasets.py#L1062) and [TorsionDriveDatasets](https://github.com/openforcefield/qcsubmit/blob/56680a7d3298b5d8962edcb840b0fdb34558c053/qcsubmit/datasets.py#L1225)
- [x] Dataset is named `dataset.json`
- [ ] A PDF depicting the molecules is attached, in the case of torsiondrives this should include the highlighting of the central bond, this can be done automatically using [qcsubmit](https://github.com/openforcefield/qcsubmit/blob/56680a7d3298b5d8962edcb840b0fdb34558c053/qcsubmit/datasets.py#L854). 
- [ ] QCSubmit validation passed
- [ ] Ready to submit!