### PR TITLE
Added prod-envs, starting with qcarchive_worker_openff.yaml

### DIFF
--- a/.github/workflows/prod-envs.yml
+++ b/.github/workflows/prod-envs.yml
@@ -1,0 +1,70 @@
+---
+# lifecycle processing for all datasets currently being tracked - backlog
+
+name: Deployment - QCArchive Prod Environments
+
+on:
+  # run whenever a pull request is labeled
+  # triggers when we add the `tracking` label
+  push:
+    branches:
+      - master
+    paths:
+      - 'devtools/prod-envs**'
+  workflow_dispatch:
+
+jobs:
+  deploy-conda-env:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Cache conda
+        uses: actions/cache@v1
+        env:
+          # Increase this value to reset cache if etc/example-environment.yml has not changed
+          CACHE_NUMBER: 0
+        with:
+          path: ~/conda_pkgs_dir
+          key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('etc/example-environment.yml') }}
+
+      #- name: Additional info about the build
+      #  shell: bash
+      #  run: |
+      #    uname -a
+      #    df -h
+      #    ulimit -a
+
+      - name: Configure conda
+        uses: goanpeca/setup-miniconda@v1
+        with:
+          python-version: 3.7
+          activate-environment: anaconda-client-env
+          environment-file: devtools/conda-envs/anaconda-client-env.yaml
+          auto-activate-base: false
+          use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
+
+      - name: Environment Information
+        shell: bash -l {0}
+        run: |
+          conda info
+          conda list
+
+      - name: Deploy conda env
+        shell: bash -l {0}
+        env:
+          ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN}}
+        run: |
+            anaconda -t ${ANACONDA_TOKEN} upload --user openforcefield devtools/prod-envs/**.yaml
+
+  #deploy-docker-image:
+  #  runs-on: ubuntu-latest
+  #  steps:
+  #    - uses: actions/checkout@v2
+  #    - name: Build and push Docker images
+  #      uses: docker/build-push-action@v1
+  #      with:
+  #        username: ${{ secrets.DOCKER_USERNAME }}
+  #        password: ${{ secrets.DOCKER_PASSWORD }}
+  #        repository: myorg/myrepository
+  #        tags: latest

--- a/.github/workflows/prod-envs.yml
+++ b/.github/workflows/prod-envs.yml
@@ -1,5 +1,5 @@
 ---
-# lifecycle processing for all datasets currently being tracked - backlog
+# deployment of qcarchive prod environments
 
 name: Deployment - QCArchive Prod Environments
 
@@ -10,7 +10,7 @@ on:
     branches:
       - master
     paths:
-      - 'devtools/prod-envs**'
+      - 'devtools/prod-envs/**.yaml'
   workflow_dispatch:
 
 jobs:
@@ -28,12 +28,12 @@ jobs:
           path: ~/conda_pkgs_dir
           key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('etc/example-environment.yml') }}
 
-      #- name: Additional info about the build
-      #  shell: bash
-      #  run: |
-      #    uname -a
-      #    df -h
-      #    ulimit -a
+      - name: Additional info about the build
+        shell: bash
+        run: |
+          uname -a
+          df -h
+          ulimit -a
 
       - name: Configure conda
         uses: goanpeca/setup-miniconda@v1

--- a/devtools/conda-envs/anaconda-client-env.yaml
+++ b/devtools/conda-envs/anaconda-client-env.yaml
@@ -1,0 +1,3 @@
+name: anaconda-client-env
+dependencies:
+  - anaconda-client

--- a/devtools/docker/README.md
+++ b/devtools/docker/README.md
@@ -1,0 +1,21 @@
+# QCFractal Dockerfiles
+
+QCFractal Dockerfiles in this directory correspond to images provided on [Docker Hub](https://cloud.docker.com/u/openff/repository/list).
+
+
+## `qcarchive_worker_openff`
+
+This Dockerfile builds a container intended to be used as a compute worker.
+It contains QCFractal as well as tools used by the [OpenFF](https://openforcefield.org/) workflow:
+
+* [Psi4](http://www.psicode.org), [dftd3](https://github.com/loriab/dftd3), and [MP2D](https://github.com/Chandemonium/MP2D>)
+* [RDKit](https://www.rdkit.org)
+* [geomeTRIC](https://github.com/leeping/geomeTRIC)
+
+including the following MM tools:
+* [openforcefield](https://github.com/openforcefield/openforcefield)
+* [openforcefields](https://github.com/openforcefield/openforcefields)
+* [openmm](https://github.com/openmm/openmm)
+* [openmmforcefields](https://github.com/openmm/openmmforcefields)
+
+Its entrypoint launches a compute manager based on the configuration file, which must be provided at `/etc/qcfractal-manager/manager.yaml`.

--- a/devtools/docker/qcarchive_worker_openff/Dockerfile
+++ b/devtools/docker/qcarchive_worker_openff/Dockerfile
@@ -1,0 +1,10 @@
+FROM continuumio/miniconda3
+SHELL ["/bin/bash", "-c"]
+RUN conda install anaconda-client
+RUN conda env create -n qcfractal qcarchive/qcarchive-worker-openff
+RUN groupadd -g 999 qcfractal && \
+    useradd -m -r -u 999 -g qcfractal qcfractal
+USER qcfractal
+ENV PATH /opt/conda/envs/qcfractal/bin/:$PATH
+RUN echo "source activate qcfractal" > ~/.bashrc
+ENTRYPOINT /bin/bash -c "source activate qcfractal && qcfractal-manager --config-file /etc/qcfractal-manager/manager.yaml -v"

--- a/devtools/docker/qcarchive_worker_openff/docker-compose.test.yml
+++ b/devtools/docker/qcarchive_worker_openff/docker-compose.test.yml
@@ -1,0 +1,4 @@
+sut:
+  build: .
+  working_dir: /home/qcfractal
+  command: pytest -v -rsx --runslow --pyargs qcfractal

--- a/devtools/prod-envs/README.md
+++ b/devtools/prod-envs/README.md
@@ -1,0 +1,22 @@
+# Production Environments
+
+This file contains production environments for the QCArchive ecosystem. These environments are for a mix
+of general compute and specific to an individual organization.
+
+Once environments are uploaded, they can be created from anywhere using the following line:
+```bash
+conda env create qcarchive/env -n env_name
+```
+
+To update an environment the current environment needs to be removed:
+```bash
+conda env remove -n env_name
+```
+It should be noted that this does not remove the packages, and creating a new environment should be very quick
+as most required packages should already be installed.
+
+To upload an environment:
+```bash
+anaconda upload --user qcarchive env.yaml
+```
+

--- a/devtools/prod-envs/README.md
+++ b/devtools/prod-envs/README.md
@@ -1,22 +1,21 @@
 # Production Environments
 
-This file contains production environments for the QCArchive ecosystem. These environments are for a mix
-of general compute and specific to an individual organization.
+This file contains production environments for OpenFF QCArchive manager deployments.
 
 Once environments are uploaded, they can be created from anywhere using the following line:
 ```bash
-conda env create qcarchive/env -n env_name
+conda env create openforcefield/<env_name> -n <env_name>
 ```
 
 To update an environment the current environment needs to be removed:
 ```bash
-conda env remove -n env_name
+conda env remove -n <env_name>
 ```
 It should be noted that this does not remove the packages, and creating a new environment should be very quick
 as most required packages should already be installed.
 
 To upload an environment:
 ```bash
-anaconda upload --user qcarchive env.yaml
+anaconda -t <api_token> upload --user openforcefield <env_file.yaml>
 ```
 

--- a/devtools/prod-envs/qcarchive-worker-openff.yaml
+++ b/devtools/prod-envs/qcarchive-worker-openff.yaml
@@ -9,7 +9,7 @@ dependencies:
   - qcfractal
 
     # Compute engines
-  - psi4 >1.4a2.dev700,<1.4a2
+  - psi4 =1.4a2.dev723+fb499f4
   - dftd3
   - gcp
   - rdkit
@@ -26,3 +26,4 @@ dependencies:
   - openforcefields >=1.2.0
   - openmm >=7.4.2
   - openmmforcefields >=0.8.0
+  - conda-forge::libiconv

--- a/devtools/prod-envs/qcarchive-worker-openff.yaml
+++ b/devtools/prod-envs/qcarchive-worker-openff.yaml
@@ -27,3 +27,6 @@ dependencies:
   - openmm >=7.4.2
   - openmmforcefields >=0.8.0
   - conda-forge::libiconv
+
+  # compute backends
+  - dask-jobqueue

--- a/devtools/prod-envs/qcarchive_worker_openff.yaml
+++ b/devtools/prod-envs/qcarchive_worker_openff.yaml
@@ -1,0 +1,28 @@
+name: qcarchive-worker-openff
+channels:
+  - defaults
+  - conda-forge
+  - psi4/label/dev
+  - omnia
+dependencies:
+  - python <=3.7
+  - qcfractal
+
+    # Compute engines
+  - psi4 >1.4a2.dev700,<1.4a2
+  - dftd3
+  - gcp
+  - rdkit
+  - qcengine >=0.15.0
+    
+    # Procedures
+  - geometric
+
+    # Testing
+  - pytest
+
+    # MM calculations
+  - openforcefield >=0.7.1
+  - openforcefields >=1.2.0
+  - openmm >=7.4.2
+  - openmmforcefields >=0.8.0


### PR DESCRIPTION
Starting with #119 we will be performing MM calculations using QCArchive, which requires use of the following packages:
- openforcefield
- openforcefields
- openmm
- openmmforcefields

These dependencies can move quickly and require adjustment based on our (OpenFF's) activities, so we are moving the conda env file for our production workers to this repository.

As part of this PR, we also want to set up Github Actions CI that pushes changes to files in the `prod-envs` directory on `master` automatically to the Anaconda Cloud. This will require an OpenFF org similar to that for [QCArchive](https://anaconda.org/qcarchive).

Likewise, we want to build and push Docker images via Github Actions for new versions of these files. This PR includes a Dockerfile for building an image using the given conda env file. Pushing built images to DockerHub will require an OpenFF org similar to that for [MolSSI](https://hub.docker.com/u/molssi).