### PR TITLE
add compute for benchmark ligands.

### DIFF
--- a/submissions/2020-07-27-OpenFF-Benchmark-Ligands/compute.json
+++ b/submissions/2020-07-27-OpenFF-Benchmark-Ligands/compute.json
@@ -1,0 +1,63 @@
+{
+  "qc_specifications": {
+    "openff_unconstrained-1.0.0": {
+      "method": "openff_unconstrained-1.0.0",
+      "basis": "smirnoff",
+      "program": "openmm",
+      "spec_name": "openff_unconstrained-1.0.0",
+      "spec_description": "Openff parsley 1.0.0 unconstrained spec.",
+      "store_wavefunction": "none"
+    }
+  },
+  "dataset_name": "OpenFF-benchmark-ligand-fragments-v1.0",
+  "dataset_tagline": "OpenForcefield TorsionDrives.",
+  "dataset_type": "TorsiondriveDataset",
+  "maxiter": 200,
+  "driver": "gradient",
+  "scf_properties": [
+    "dipole",
+    "quadrupole",
+    "wiberg_lowdin_indices",
+    "mayer_indices"
+  ],
+  "priority": "normal",
+  "description": "A TorsionDrive dataset using geometric.",
+  "dataset_tags": [
+    "openff"
+  ],
+  "compute_tag": "openff",
+  "metadata": {
+    "submitter": "joshuahorton",
+    "creation_date": "2020-08-14",
+    "collection_type": "TorsiondriveDataset",
+    "dataset_name": "TorsionDriveDataset",
+    "short_description": "OpenForcefield TorsionDrives.",
+    "long_description_url": null,
+    "long_description": "A TorsionDrive dataset using geometric.",
+    "elements": []
+  },
+  "provenance": {},
+  "dataset": {},
+  "filtered_molecules": {},
+  "optimization_procedure": {
+    "program": "geometric",
+    "coordsys": "tric",
+    "enforce": 0.1,
+    "epsilon": 0.0,
+    "reset": true,
+    "qccnv": true,
+    "molcnv": false,
+    "check": 0,
+    "trust": 0.1,
+    "tmax": 0.3,
+    "maxiter": 300,
+    "convergence_set": "GAU",
+    "constraints": {}
+  },
+  "grid_spacings": [
+    15
+  ],
+  "energy_upper_limit": 0.05,
+  "dihedral_ranges": null,
+  "energy_decrease_thresh": null
+}


### PR DESCRIPTION
This PR will add a new compute specification to the OpenFF-benchmark-ligand-fragments-v1.0 dataset to run an unconstrained version of parsley. 

The management script may need to be updated to also accept these `compute.json` files.

- [ ] QCSubmit validation passed
- [ ] Ready to submit!