### PR TITLE
Added individual prod environments for different QCEngine harnesses

### DIFF
--- a/.github/workflows/prod-envs.yml
+++ b/.github/workflows/prod-envs.yml
@@ -4,8 +4,6 @@
 name: Deployment - QCArchive Prod Environments
 
 on:
-  # run whenever a pull request is labeled
-  # triggers when we add the `tracking` label
   push:
     branches:
       - master
@@ -56,15 +54,3 @@ jobs:
           ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN}}
         run: |
             anaconda -t ${ANACONDA_TOKEN} upload --user openforcefield devtools/prod-envs/**.yaml
-
-  #deploy-docker-image:
-  #  runs-on: ubuntu-latest
-  #  steps:
-  #    - uses: actions/checkout@v2
-  #    - name: Build and push Docker images
-  #      uses: docker/build-push-action@v1
-  #      with:
-  #        username: ${{ secrets.DOCKER_USERNAME }}
-  #        password: ${{ secrets.DOCKER_PASSWORD }}
-  #        repository: myorg/myrepository
-  #        tags: latest

--- a/devtools/prod-envs/qcarchive-worker-openff-ani.yaml
+++ b/devtools/prod-envs/qcarchive-worker-openff-ani.yaml
@@ -7,10 +7,10 @@ channels:
 dependencies:
   - python =3.7
   - qcfractal
-  - qcengine =0.15.0
+  - qcengine =0.16.0
 
   # ML calculations
-  - pytorch
+  - pytorch =1.6.0
 
   # procedures
   - geometric
@@ -19,4 +19,4 @@ dependencies:
   - dask-jobqueue
 
   - pip:
-    - torchani
+    - torchani =2.2

--- a/devtools/prod-envs/qcarchive-worker-openff-ani.yaml
+++ b/devtools/prod-envs/qcarchive-worker-openff-ani.yaml
@@ -1,11 +1,11 @@
 name: qcarchive-worker-openff-ani
-channel_priority: flexible
 channels:
   - conda-forge
-  - pytorch-nightly
+  - pytorch
   - defaults
 dependencies:
   - python =3.7
+  - pip
   - qcfractal
   - qcengine =0.16.0
 
@@ -19,4 +19,4 @@ dependencies:
   - dask-jobqueue
 
   - pip:
-    - torchani =2.2
+    - torchani ==2.2

--- a/devtools/prod-envs/qcarchive-worker-openff-ani.yaml
+++ b/devtools/prod-envs/qcarchive-worker-openff-ani.yaml
@@ -1,0 +1,22 @@
+name: qcarchive-worker-openff-ani
+channel_priority: flexible
+channels:
+  - conda-forge
+  - pytorch-nightly
+  - defaults
+dependencies:
+  - python =3.7
+  - qcfractal
+  - qcengine =0.15.0
+
+  # ML calculations
+  - pytorch
+
+  # procedures
+  - geometric
+
+  # compute backends
+  - dask-jobqueue
+
+  - pip:
+    - torchani

--- a/devtools/prod-envs/qcarchive-worker-openff-openmm.yaml
+++ b/devtools/prod-envs/qcarchive-worker-openff-openmm.yaml
@@ -1,19 +1,13 @@
-name: qcarchive-worker-openff
+name: qcarchive-worker-openff-openmm
 channel_priority: flexible
 channels:
   - conda-forge
-  - psi4/label/dev
   - omnia
   - defaults
 dependencies:
   - python =3.7
   - qcfractal
   - qcengine =0.15.0
-
-  # QM calculations
-  - psi4 =1.4a2.dev723+fb499f4
-  - dftd3
-  - gcp
     
   # MM calculations
   - openforcefield =0.7.1

--- a/devtools/prod-envs/qcarchive-worker-openff-openmm.yaml
+++ b/devtools/prod-envs/qcarchive-worker-openff-openmm.yaml
@@ -1,5 +1,4 @@
 name: qcarchive-worker-openff-openmm
-channel_priority: flexible
 channels:
   - conda-forge
   - omnia

--- a/devtools/prod-envs/qcarchive-worker-openff-openmm.yaml
+++ b/devtools/prod-envs/qcarchive-worker-openff-openmm.yaml
@@ -7,7 +7,7 @@ channels:
 dependencies:
   - python =3.7
   - qcfractal
-  - qcengine =0.15.0
+  - qcengine =0.16.0
     
   # MM calculations
   - openforcefield =0.7.1

--- a/devtools/prod-envs/qcarchive-worker-openff-psi4.yaml
+++ b/devtools/prod-envs/qcarchive-worker-openff-psi4.yaml
@@ -1,9 +1,8 @@
-name: qcarchive-worker-openff
+name: qcarchive-worker-openff-psi4
 channel_priority: flexible
 channels:
   - conda-forge
   - psi4/label/dev
-  - omnia
   - defaults
 dependencies:
   - python =3.7
@@ -15,13 +14,6 @@ dependencies:
   - dftd3
   - gcp
     
-  # MM calculations
-  - openforcefield =0.7.1
-  - openforcefields =1.2.0
-  - openmm =7.4.2
-  - openmmforcefields =0.8.0
-  - conda-forge::libiconv
-
   # procedures
   - geometric
 

--- a/devtools/prod-envs/qcarchive-worker-openff-psi4.yaml
+++ b/devtools/prod-envs/qcarchive-worker-openff-psi4.yaml
@@ -1,5 +1,4 @@
 name: qcarchive-worker-openff-psi4
-channel_priority: flexible
 channels:
   - conda-forge
   - psi4/label/dev

--- a/devtools/prod-envs/qcarchive-worker-openff-psi4.yaml
+++ b/devtools/prod-envs/qcarchive-worker-openff-psi4.yaml
@@ -7,7 +7,7 @@ channels:
 dependencies:
   - python =3.7
   - qcfractal
-  - qcengine =0.15.0
+  - qcengine =0.16.0
 
   # QM calculations
   - psi4 =1.4a2.dev723+fb499f4

--- a/devtools/prod-envs/qcarchive-worker-openff.yaml
+++ b/devtools/prod-envs/qcarchive-worker-openff.yaml
@@ -4,6 +4,7 @@ channels:
   - conda-forge
   - psi4/label/dev
   - omnia
+  - pytorch-nightly
   - defaults
 dependencies:
   - python =3.7
@@ -22,8 +23,14 @@ dependencies:
   - openmmforcefields =0.8.0
   - conda-forge::libiconv
 
+  # ML calculations
+  - pytorch =1.6.0
+
   # procedures
   - geometric
 
   # compute backends
   - dask-jobqueue
+
+  - pip:
+    - torchani =2.2

--- a/devtools/prod-envs/qcarchive-worker-openff.yaml
+++ b/devtools/prod-envs/qcarchive-worker-openff.yaml
@@ -8,7 +8,7 @@ channels:
 dependencies:
   - python =3.7
   - qcfractal
-  - qcengine =0.15.0
+  - qcengine =0.16.0
 
   # QM calculations
   - psi4 =1.4a2.dev723+fb499f4

--- a/devtools/prod-envs/qcarchive-worker-openff.yaml
+++ b/devtools/prod-envs/qcarchive-worker-openff.yaml
@@ -1,13 +1,13 @@
 name: qcarchive-worker-openff
-channel_priority: flexible
 channels:
   - conda-forge
   - psi4/label/dev
   - omnia
-  - pytorch-nightly
+  - pytorch
   - defaults
 dependencies:
   - python =3.7
+  - pip
   - qcfractal
   - qcengine =0.16.0
 
@@ -33,4 +33,4 @@ dependencies:
   - dask-jobqueue
 
   - pip:
-    - torchani =2.2
+    - torchani ==2.2


### PR DESCRIPTION
We have recently found cases where certain libraries in our conda environment installs can conflict with one another in their dependencies, especially across different channels. To mitigate this in our production QCArchive worker environments, we have decided to create separate environments for different task types, namely:
- MM (OpenMM, openforcefield, ambertools, etc.)
- QM (psi4, dftd3, gcp, etc.)
- ML (torchani, pytorch)

This PR adds these production environments. It also updates the existing `qcarchive-worker-openff.yaml` environment currently used for QM+MM deployments, which currently covers common workload types we are computing. We have decided to pin our MM dependencies to specific versions so we can deliberately choose when to upgrade these in production.