### PR TITLE
Adding policy for major versioning, expanding submissions in STANDARDS

### DIFF
--- a/LEGACY.md
+++ b/LEGACY.md
@@ -1,0 +1,32 @@
+## Dataset Priority
+
+This section contains a relative ranking of dataset priority.
+
+While queueing is still handled manually, *this* is the single place where priority is determined.
+
+New datasets that are added should be included in this list if they are to be submitted.
+
+Do not modify this directly in master -- Always open a PR and get at least one approving review before merging.
+
+* ~Roche hessians~
+* ~Coverage hessians~
+* ~Chaya's Biphenyl set~
+* ~Boron~
+* 06-28-19-Nitrogen-grid-optimization
+* Everything else
+
+Look into Roche torsion set to investigate/fix failures.
+
+# qca-dataset-submission
+Data generation and submission scripts for the QCArchive ecosystem.
+
+## `TorsionDriveDataset`
+* `2019-06-03-Torsion-Stability-Benchmark`: source files for `Fragment Stability Benchmark` (`TorsionDriveDataset`) covering molecular fragments of varying size around a central torsion (@ChayaSt)
+* `2019-07-25-phenyl-set`: source files for `phenyl set`
+* `2019-09-07-Pfizer-discrepancy-torsion-dataset-1`: source files for `Pfizer discrepancy torsion dataset 1`
+
+## `OptimizationDataset`
+* `2019-06-25-smirnoff99Frost-coverage`: source files for `smirnoff99Frost parameter coverage` (`OptimizationDataset`) providing minimal coverage of SMIRNOFF valence parameters (@ChayaSt)
+* `2019-07-02 VEHICLe optimization dataset`: source files for `Open Force Field VEHICLe optimization dataset 1.0.0` (`OptimizationDataset`) for the VEHICLe dataset (heteraromatic rings of the future) (@jchodera)
+* `2019-07-05 OpenFF NCI250K Boron 1`: source files for `OpenMM NCI250K Boron 1` (`OptimizationDataset`) where small boron-containing compounds are extracted from the [NCI250K](https://cactus.nci.nih.gov/download/nci/) (@jchodera)
+* `2019-09-07-Pfizer-discrepancy-optimization-dataset-1`: source files for `Pfizer discrepancy optimization dataset 1` (@jchodera)

--- a/README.md
+++ b/README.md
@@ -1,15 +1,45 @@
 # OpenFF QCArchive Dataset Submission
 
-All datasets submitted to QCArchive via this repository conform to the [Dataset Standards](./STANDARDS.md).
+All datasets submitted to [QCArchive](https://qcarchive.molssi.org/) via this repository conform to the [Dataset Standards](./STANDARDS.md).
 The procedures outlined below are designed to make this as straightforward as possible for submitters.
 
 ## Making a submission
 
+**Note**: Making submissions requires being a maintainer on this repository.
+          Open an issue if you would like to contribute to this project and make submissions to QCArchive.
+
+To make a new submission, make a PR from a branch on this repository:
+
+1. Clone this repository to your local machine.
+
+2. Create and switch to a new branch:
+
+        git checkout -b <new-submission-branch-name>
+
+3. Create a directory in `./submissions`:
+
+        mkdir submissions/<yyyy-mm-dd>-<new-submission-name>
+
+4. Use QCSubmit to prepare your `dataset.json` in that directory:
+
+
+
+5. When validation checks pass and a reviewer has approved your submission, it will be merged.
+   Submission to the public QCArchive will follow automatically.
+
+
 ## The lifecycle of a dataset
 
-[Dataset Lifecycle](./LIFECYCLE.md)
+Following submission, datasets are carried to completion by a well-defined [Dataset Lifecycle](./LIFECYCLE.md).
+Much of this lifecycle is automated, with status indicated on the [Dataset Tracking](https://github.com/openforcefield/qca-dataset-submission/projects/1?fullscreen=true) board.
+
+No further action from the submitter is required, unless the submission is placed in "Requires Scientific Review".
+In this case, the submitter will be contacted to decide on next steps.
+
 
 ## Adding molecules to a submission
+
+
 
 ## Adding compute to a submission
 

--- a/README.md
+++ b/README.md
@@ -1,42 +1,16 @@
 # OpenFF QCArchive Dataset Submission
 
-## Dataset Lifecycle
+All datasets submitted to QCArchive via this repository conform to the [Dataset Standards](./STANDARDS.md).
+The procedures outlined below are designed to make this as straightforward as possible for submitters.
 
-All datasets submitted to QCArchive via this repository conform to the [Dataset Lifecycle](./LIFECYCLE.md).
+## Making a submission
 
-See [STANDARDS.md](./STANDARDS.md) for submission standards.
-Datasets must be submitted as pull requests.
+## The lifecycle of a dataset
+
+[Dataset Lifecycle](./LIFECYCLE.md)
+
+## Adding molecules to a submission
+
+## Adding compute to a submission
 
 
-## Dataset Priority
-
-This section contains a relative ranking of dataset priority.
-
-While queueing is still handled manually, *this* is the single place where priority is determined.
-
-New datasets that are added should be included in this list if they are to be submitted.
-
-Do not modify this directly in master -- Always open a PR and get at least one approving review before merging.
-
-* ~Roche hessians~
-* ~Coverage hessians~
-* ~Chaya's Biphenyl set~
-* ~Boron~
-* 06-28-19-Nitrogen-grid-optimization
-* Everything else
-
-Look into Roche torsion set to investigate/fix failures.
-
-# qca-dataset-submission
-Data generation and submission scripts for the QCArchive ecosystem.
-
-## `TorsionDriveDataset`
-* `2019-06-03-Torsion-Stability-Benchmark`: source files for `Fragment Stability Benchmark` (`TorsionDriveDataset`) covering molecular fragments of varying size around a central torsion (@ChayaSt)
-* `2019-07-25-phenyl-set`: source files for `phenyl set`
-* `2019-09-07-Pfizer-discrepancy-torsion-dataset-1`: source files for `Pfizer discrepancy torsion dataset 1`
-
-## `OptimizationDataset`
-* `2019-06-25-smirnoff99Frost-coverage`: source files for `smirnoff99Frost parameter coverage` (`OptimizationDataset`) providing minimal coverage of SMIRNOFF valence parameters (@ChayaSt)
-* `2019-07-02 VEHICLe optimization dataset`: source files for `Open Force Field VEHICLe optimization dataset 1.0.0` (`OptimizationDataset`) for the VEHICLe dataset (heteraromatic rings of the future) (@jchodera)
-* `2019-07-05 OpenFF NCI250K Boron 1`: source files for `OpenMM NCI250K Boron 1` (`OptimizationDataset`) where small boron-containing compounds are extracted from the [NCI250K](https://cactus.nci.nih.gov/download/nci/) (@jchodera)
-* `2019-09-07-Pfizer-discrepancy-optimization-dataset-1`: source files for `Pfizer discrepancy optimization dataset 1` (@jchodera)

--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -25,7 +25,6 @@ The following compute specs are required for a submission:
     - `method`: `'gaff-2.11'`
     - `basis`: `'antechamber'`
 
-
 ## Best practices
 
 * If any calculations are to be redone from another collection, re-use the old input (coordinates, atom ordering etc) as this will avoid running the calculation again and will just create new references in the database to the old results and should help keep the cost of the calculations down.  
@@ -50,16 +49,17 @@ Each dataset shall be versioned.
     - new molecules or conformers added
     - problematic molecules removed
 
+Operationally, datasets are defined in `dataset.json` files in this repository.
+
 ## Adding new compute to old datasets
 
+New compute specifications can be added to an existing dataset **without** a version update.
+These are considered supplementary to the original submisison, and do not factor into its identity or completeness status.
+    
+- The dataset should be of the correct type and have the name set to that in the archive.
+- The dataset entries should be empty and only the new `qc_specifications` section should be filled in.
 
-
-Datasets now support multiple QC specifications and will start compute for them all simultaneously when submitted.
-However in some cases you may want to add new specifications to old datasets already in the archive, to do this make a PR in the normal way with either a `dataset.json` or `compute.json` qcsubmit dataset. 
-The dataset should be of the correct type and have the name set to that in the archive.
-The dataset entries should be empty and only the new `qc_specifications` section should be filled in which will cause the 
-CI to search the public archive for the dataset and validate the basis coverage before submitting. 
-
+Operationally, supplemental compute for a dataset are defined in `compute*.json` files.
 
 ## Tags indicate status
 
@@ -97,5 +97,3 @@ The dataset's group should be set to `"OpenFF"`.
 ### Required fields
 
 * See ["Fields that should be required for OpenFF submissions"](https://github.com/openforcefield/qcsubmit/issues/3)
-
-

--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -9,12 +9,31 @@ Current list:
 * Ensure all submissions have cmiles, most important are mapped hydrogen smiles
 * Ensure the WBO is requested for all submissions, this should be included in the scf properties list using the flag `wiberg_lowdin_indices`
 
+## Required compute
+
+The following compute specs are required for a submission:
+
+- `default`:
+    - `method`: `'B3LYP-D3BJ'`
+    - `basis`: `'DZVP'`
+    - `program`: `'psi4'`
+- `openff-1.0.0`:
+    - `method`: `'openff-1.0.0'`
+    - `basis`: `'smirnoff'`
+    - `program`: `'openmm'`
+- `gaff-2.11`:
+    - `method`: `'gaff-2.11'`
+    - `basis`: `'antechamber'`
+
+
 ## Best practices
+
 * If any calculations are to be redone from another collection, re-use the old input (coordinates, atom ordering etc) as this will avoid running the calculation again and will just create new references in the database to the old results and should help keep the cost of the calculations down.  
 
 ## Dataset naming and versioning
 
 Each dataset shall be versioned.
+
 - The naming of a dataset should have the following structure:
 
     `"OpenFF <descriptive and uniquely-identifying name> v<version number>"`
@@ -26,6 +45,21 @@ Each dataset shall be versioned.
 - A minor version change (e.g. `"v1.1"`) means cosmetic or minor additions/problems were addressed
     - mispelling
     - addition of a e.g. Wiberg bond orders
+
+- A major version change (e.g. `"v2.0"`) means major additions/problems were made/addressed
+    - new molecules or conformers added
+    - problematic molecules removed
+
+## Adding new compute to old datasets
+
+
+
+Datasets now support multiple QC specifications and will start compute for them all simultaneously when submitted.
+However in some cases you may want to add new specifications to old datasets already in the archive, to do this make a PR in the normal way with either a `dataset.json` or `compute.json` qcsubmit dataset. 
+The dataset should be of the correct type and have the name set to that in the archive.
+The dataset entries should be empty and only the new `qc_specifications` section should be filled in which will cause the 
+CI to search the public archive for the dataset and validate the basis coverage before submitting. 
+
 
 ## Tags indicate status
 
@@ -65,8 +99,3 @@ The dataset's group should be set to `"OpenFF"`.
 * See ["Fields that should be required for OpenFF submissions"](https://github.com/openforcefield/qcsubmit/issues/3)
 
 
-### Adding Compute to old datasets
-Datasets now support multiple QC specifications and will start compute for them all simultaneously when submitted.
-However in some cases you may want to add new specifications to old datasets already in the archive, to do this make a PR in the normal way with either a `dataset.json` or `compute.json` qcsubmit dataset. 
-The dataset should be of the correct type and have the name set to that in the archive.   The dataset entries should be empty and only the new `qc_specifications` section should be filled in which will cause the 
-CI to search the public archive for the dataset and validate the basis coverage before submitting. 


### PR DESCRIPTION
Also, adding the current recommended submission procedures in [README](https://github.com/openforcefield/qca-dataset-submission/blob/expanding-submissions/README.md) for our users that:
1. conform to our [STANDARDS](https://github.com/openforcefield/qca-dataset-submission/blob/expanding-submissions/STANDARDS.md)
2. are handled cleanly by our [LIFECYCLE](https://github.com/openforcefield/qca-dataset-submission/blob/expanding-submissions/LIFECYCLE.md) automation