### PR TITLE
Updated prod envs to use qcfractal 0.14.0, latest openff packages

### DIFF
--- a/devtools/prod-envs/qcarchive-worker-openff-ani.yaml
+++ b/devtools/prod-envs/qcarchive-worker-openff-ani.yaml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - python =3.7
   - pip
-  - qcfractal
+  - qcfractal =0.14.0
   - qcengine =0.16.0
 
   # ML calculations

--- a/devtools/prod-envs/qcarchive-worker-openff-ani.yaml
+++ b/devtools/prod-envs/qcarchive-worker-openff-ani.yaml
@@ -7,7 +7,7 @@ dependencies:
   - python =3.7
   - pip
   - qcfractal =0.14.0
-  - qcengine =0.16.0
+  - qcengine =0.17.0
 
   # ML calculations
   - pytorch =1.6.0

--- a/devtools/prod-envs/qcarchive-worker-openff-openmm.yaml
+++ b/devtools/prod-envs/qcarchive-worker-openff-openmm.yaml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - python =3.7
   - qcfractal =0.14.0
-  - qcengine =0.16.0
+  - qcengine =0.17.0
     
   # MM calculations
   - openforcefield =0.7.2

--- a/devtools/prod-envs/qcarchive-worker-openff-openmm.yaml
+++ b/devtools/prod-envs/qcarchive-worker-openff-openmm.yaml
@@ -5,12 +5,12 @@ channels:
   - defaults
 dependencies:
   - python =3.7
-  - qcfractal
+  - qcfractal =0.14.0
   - qcengine =0.16.0
     
   # MM calculations
-  - openforcefield =0.7.1
-  - openforcefields =1.2.0
+  - openforcefield =0.7.2
+  - openforcefields =1.2.1
   - openmm =7.4.2
   - openmmforcefields =0.8.0
   - conda-forge::libiconv

--- a/devtools/prod-envs/qcarchive-worker-openff-psi4.yaml
+++ b/devtools/prod-envs/qcarchive-worker-openff-psi4.yaml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - python =3.7
   - qcfractal =0.14.0
-  - qcengine =0.16.0
+  - qcengine =0.17.0
 
   # QM calculations
   - psi4 =1.4a2.dev723+fb499f4

--- a/devtools/prod-envs/qcarchive-worker-openff-psi4.yaml
+++ b/devtools/prod-envs/qcarchive-worker-openff-psi4.yaml
@@ -5,7 +5,7 @@ channels:
   - defaults
 dependencies:
   - python =3.7
-  - qcfractal
+  - qcfractal =0.14.0
   - qcengine =0.16.0
 
   # QM calculations

--- a/devtools/prod-envs/qcarchive-worker-openff-xtb.yaml
+++ b/devtools/prod-envs/qcarchive-worker-openff-xtb.yaml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - python =3.7
   - qcfractal =0.14.0
-  - qcengine =0.16.0
+  - qcengine =0.17.0
 
   # QM calculations
   - xtb-python =20.1

--- a/devtools/prod-envs/qcarchive-worker-openff-xtb.yaml
+++ b/devtools/prod-envs/qcarchive-worker-openff-xtb.yaml
@@ -1,0 +1,20 @@
+name: qcarchive-worker-openff-xtb
+channels:
+  - conda-forge
+  - psi4/label/dev
+  - defaults
+dependencies:
+  - python =3.7
+  - qcfractal =0.14.0
+  - qcengine =0.16.0
+
+  # QM calculations
+  - xtb-python =20.1
+  - dftd3
+  - gcp
+    
+  # procedures
+  - geometric
+
+  # compute backends
+  - dask-jobqueue

--- a/devtools/prod-envs/qcarchive-worker-openff.yaml
+++ b/devtools/prod-envs/qcarchive-worker-openff.yaml
@@ -9,7 +9,7 @@ dependencies:
   - python =3.7
   - pip
   - qcfractal =0.14.0
-  - qcengine =0.16.0
+  - qcengine =0.17.0
 
   # QM calculations
   - psi4 =1.4a2.dev723+fb499f4

--- a/devtools/prod-envs/qcarchive-worker-openff.yaml
+++ b/devtools/prod-envs/qcarchive-worker-openff.yaml
@@ -13,6 +13,7 @@ dependencies:
 
   # QM calculations
   - psi4 =1.4a2.dev723+fb499f4
+  - xtb-python =20.1
   - dftd3
   - gcp
     

--- a/devtools/prod-envs/qcarchive-worker-openff.yaml
+++ b/devtools/prod-envs/qcarchive-worker-openff.yaml
@@ -8,7 +8,7 @@ channels:
 dependencies:
   - python =3.7
   - pip
-  - qcfractal
+  - qcfractal =0.14.0
   - qcengine =0.16.0
 
   # QM calculations
@@ -17,8 +17,8 @@ dependencies:
   - gcp
     
   # MM calculations
-  - openforcefield =0.7.1
-  - openforcefields =1.2.0
+  - openforcefield =0.7.2
+  - openforcefields =1.2.1
   - openmm =7.4.2
   - openmmforcefields =0.8.0
   - conda-forge::libiconv


### PR DESCRIPTION
This PR updates all prod environments to use `qcfractal 0.14.0` explicitly, as well as pinning to the latest versions of `openforcefield`, `openforcefields` where used.

A QCEngine release may be imminent, so we will wait for word on this before merge and deployment. That will give us improvements for both the Psi4 and ANI harnesses that we really want for production use.