### PR TITLE
Added supplemental compute spec to OpenFF Substituted Phenyl Set 1

### DIFF
--- a/submissions/2019-07-25-phenyl-set/README.md
+++ b/submissions/2019-07-25-phenyl-set/README.md
@@ -34,6 +34,6 @@
 Added compute expansion with the following specs in `compute.json`:
 - default (already computed)
 - openff-1.0.0
-- openff-1.0.0
-- openff-1.0.0
+- openff-1.2.0
+- openff-1.2.1
 - gaff-2.11

--- a/submissions/2019-07-25-phenyl-set/README.md
+++ b/submissions/2019-07-25-phenyl-set/README.md
@@ -32,7 +32,6 @@
 
 ## Compute expansion 2020.10.02 (dotsdl)
 Added compute expansion with the following specs in `compute.json`:
-- default (already computed)
 - openff-1.0.0
 - openff-1.2.0
 - openff-1.2.1

--- a/submissions/2019-07-25-phenyl-set/README.md
+++ b/submissions/2019-07-25-phenyl-set/README.md
@@ -29,3 +29,11 @@
 
 ## Note 2020-05--07
 5 new biphenyl molecules were added to this set.
+
+## Compute expansion 2020.10.02 (dotsdl)
+Added compute expansion with the following specs in `compute.json`:
+- default (already computed)
+- openff-1.0.0
+- openff-1.0.0
+- openff-1.0.0
+- gaff-2.11

--- a/submissions/2019-07-25-phenyl-set/compute.json
+++ b/submissions/2019-07-25-phenyl-set/compute.json
@@ -54,10 +54,10 @@
     "submitter": "dotsdl",
     "creation_date": "2020-10-02",
     "collection_type": "TorsiondriveDataset",
-    "dataset_name": "TorsionDriveDataset",
-    "short_description": "OpenForcefield TorsionDrives.",
+    "dataset_name": "OpenFF Substituted Phenyl Set 1",
+    "short_description": "TorsionDrives for WBOs, torsion relationship",
     "long_description_url": null,
-    "long_description": "A TorsionDrive dataset using geometric.",
+    "long_description": "A TorsionDrive dataset using geometric; investigating WBO and torsion barrier relationship",
     "elements": []
   },
   "provenance": {},

--- a/submissions/2019-07-25-phenyl-set/compute.json
+++ b/submissions/2019-07-25-phenyl-set/compute.json
@@ -1,0 +1,95 @@
+{
+  "qc_specifications": {
+    "default": {
+      "method": "B3LYP-D3BJ",
+      "basis": "DZVP",
+      "program": "psi4",
+      "spec_name": "default",
+      "spec_description": "Standard OpenFF optimization quantum chemistry specification.",
+      "store_wavefunction": "none"
+    },
+    "openff-1.0.0": {
+      "method": "openff-1.0.0",
+      "basis": "smirnoff",
+      "program": "openmm",
+      "spec_name": "openff-1.0.0",
+      "spec_description": "default openff-1.0.0 spec",
+      "store_wavefunction": "none"
+    },
+    "openff-1.2.0": {
+      "method": "openff-1.2.0",
+      "basis": "smirnoff",
+      "program": "openmm",
+      "spec_name": "openff-1.2.0",
+      "spec_description": "default openff-1.2.0 spec",
+      "store_wavefunction": "none"
+    },
+    "openff-1.2.1": {
+      "method": "openff-1.2.1",
+      "basis": "smirnoff",
+      "program": "openmm",
+      "spec_name": "openff-1.2.1",
+      "spec_description": "default openff-1.2.1 spec",
+      "store_wavefunction": "none"
+    },
+    "gaff-2.11": {
+      "method": "gaff-2.11",
+      "basis": "antechamber",
+      "program": "openmm",
+      "spec_name": "gaff-2.11",
+      "spec_description": "default gaff-2.11 spec",
+      "store_wavefunction": "none"
+    }
+  },
+  "dataset_name": "OpenFF Substituted Phenyl Set 1",
+  "dataset_tagline": "OpenForcefield TorsionDrives.",
+  "dataset_type": "TorsiondriveDataset",
+  "maxiter": 200,
+  "driver": "gradient",
+  "scf_properties": [
+    "dipole",
+    "quadrupole",
+    "wiberg_lowdin_indices",
+    "mayer_indices"
+  ],
+  "priority": "normal",
+  "description": "A TorsionDrive dataset using geometric.",
+  "dataset_tags": [
+    "openff"
+  ],
+  "compute_tag": "openff",
+  "metadata": {
+    "submitter": "dotsdl",
+    "creation_date": "2020-10-02",
+    "collection_type": "TorsiondriveDataset",
+    "dataset_name": "TorsionDriveDataset",
+    "short_description": "OpenForcefield TorsionDrives.",
+    "long_description_url": null,
+    "long_description": "A TorsionDrive dataset using geometric.",
+    "elements": []
+  },
+  "provenance": {},
+  "dataset": {},
+  "filtered_molecules": {},
+  "optimization_procedure": {
+    "program": "geometric",
+    "coordsys": "tric",
+    "enforce": 0.1,
+    "epsilon": 0.0,
+    "reset": true,
+    "qccnv": true,
+    "molcnv": false,
+    "check": 0,
+    "trust": 0.1,
+    "tmax": 0.3,
+    "maxiter": 300,
+    "convergence_set": "GAU",
+    "constraints": {}
+  },
+  "grid_spacings": [
+    15
+  ],
+  "energy_upper_limit": 0.05,
+  "dihedral_ranges": null,
+  "energy_decrease_thresh": null
+}

--- a/submissions/2019-07-25-phenyl-set/compute.json
+++ b/submissions/2019-07-25-phenyl-set/compute.json
@@ -1,13 +1,5 @@
 {
   "qc_specifications": {
-    "default": {
-      "method": "B3LYP-D3BJ",
-      "basis": "DZVP",
-      "program": "psi4",
-      "spec_name": "default",
-      "spec_description": "Standard OpenFF optimization quantum chemistry specification.",
-      "store_wavefunction": "none"
-    },
     "openff-1.0.0": {
       "method": "openff-1.0.0",
       "basis": "smirnoff",


### PR DESCRIPTION
This PR expands the existing "OpenFF Substituted Phenyl Set 1" TorsionDrive dataset to include additional compute specs. We include the following here:
- default (already computed)
- openff-1.0.0
- openff-1.2.0
- openff-1.2.1
- gaff-2.11

----
- [ ] Created a new folder in the submissions directory containing the dataset
- [x] Added README.md describing the dataset see [here](https://github.com/openforcefield/qca-dataset-submission/tree/master/submissions/2020-03-26-OpenFF-Gen-2-Torsion-Set-6-supplemental-2) for examples
- [x] All files used to produce the dataset are included with a description
- [ ] Dataset follows the QCSubmit schema defined for [Datasets](https://github.com/openforcefield/qcsubmit/blob/56680a7d3298b5d8962edcb840b0fdb34558c053/qcsubmit/datasets.py#L340), [OptimizationDatasets](https://github.com/openforcefield/qcsubmit/blob/56680a7d3298b5d8962edcb840b0fdb34558c053/qcsubmit/datasets.py#L1062) and [TorsionDriveDatasets](https://github.com/openforcefield/qcsubmit/blob/56680a7d3298b5d8962edcb840b0fdb34558c053/qcsubmit/datasets.py#L1225)
- [ ] Dataset is named `dataset.json`
- [x] A PDF depicting the molecules is attached, in the case of torsiondrives this should include the highlighting of the central bond, this can be done automatically using [qcsubmit](https://github.com/openforcefield/qcsubmit/blob/56680a7d3298b5d8962edcb840b0fdb34558c053/qcsubmit/datasets.py#L854). 
- [ ] QCSubmit validation passed
- [ ] Ready to submit!