### PR TITLE
xtb Compute for the fragmented ligand set.

### DIFF
--- a/management/validation.py
+++ b/management/validation.py
@@ -5,6 +5,7 @@ Script to run validation using qcsubmit on dataset_fragments.json files
 import copy
 import json
 import os
+import glob
 from argparse import ArgumentParser
 
 
@@ -323,7 +324,9 @@ def main():
     file_names = json.loads(args.dataset_files)
     dataset_paths = []
     for file in file_names:
-        if "compute.json" in file or "dataset.json" in file:
+        if "dataset.json" in file:
+            dataset_paths.append(file)
+        elif glob.fnmatch.fnmatch(file, "compute*.json"):
             dataset_paths.append(file)
 
     comment = main_validation(dataset_paths)

--- a/management/validation.py
+++ b/management/validation.py
@@ -326,7 +326,7 @@ def main():
     for file in file_names:
         if "dataset.json" in file:
             dataset_paths.append(file)
-        elif glob.fnmatch.fnmatch(file, "compute*.json"):
+        elif glob.fnmatch.fnmatch(os.path.basename(file), "compute*.json"):
             dataset_paths.append(file)
 
     comment = main_validation(dataset_paths)

--- a/submissions/2020-07-27-OpenFF-Benchmark-Ligands/README.md
+++ b/submissions/2020-07-27-OpenFF-Benchmark-Ligands/README.md
@@ -36,14 +36,37 @@ This is a torsiondrive dataset created from the [OpenFF FEP benchmark dataset](h
         - name: default
         - method: B3LYP-D3BJ
         - basis: DZVP
+        - program: psi4
     - openff-1.0.0:
         - name: openff-1.0.0
         - method: openff-1.0.0
         - basis: smirnoff
+        - program: openmm
     - gaff-2.11:
         - name: gaff-2.11
         - method: gaff-2.11
         - basis: antechamber
+        - program: openmm
+    - ani2x:
+        - name: ani2x
+        - method: ani2x
+        - basis: None
+        - program: torchani
+    - gfn2xtb:
+        - name: gfn2xtb
+        - method: gfn2xtb
+        - basis: None
+        - program: xtb
+    - gfn1xtb:
+        - name: gfn1xtb 
+        - method: gfn1xtb
+        - basis: None
+        - program: xtb
+    - gfnff:
+        - name: gfnff
+        - method: gfnff
+        - basis: None
+        - program: xtb
      
     
     

--- a/submissions/2020-07-27-OpenFF-Benchmark-Ligands/compute_xtb.json
+++ b/submissions/2020-07-27-OpenFF-Benchmark-Ligands/compute_xtb.json
@@ -1,0 +1,79 @@
+{
+  "qc_specifications": {
+    "gfn2xtb": {
+      "method": "gfn2xtb",
+      "basis": null,
+      "program": "xtb",
+      "spec_name": "gfn2xtb",
+      "spec_description": "GFN2xtb standard spec.",
+      "store_wavefunction": "none"
+    },
+    "gfn1xtb": {
+      "method": "gfn1xtb",
+      "basis": null,
+      "program": "xtb",
+      "spec_name": "gfn1xtb",
+      "spec_description": "GFN1xtb standard spec.",
+      "store_wavefunction": "none"
+    },
+    "gfnff": {
+      "method": "gfnff",
+      "basis": null,
+      "program": "xtb",
+      "spec_name": "gfnff",
+      "spec_description": "GFNff The xtb forcefield spec.",
+      "store_wavefunction": "none"
+    }
+  },
+  "dataset_name": "OpenFF-benchmark-ligand-fragments-v1.0",
+  "dataset_tagline": "OpenForcefield TorsionDrives.",
+  "dataset_type": "TorsiondriveDataset",
+  "maxiter": 200,
+  "driver": "gradient",
+  "scf_properties": [
+    "dipole",
+    "quadrupole",
+    "wiberg_lowdin_indices",
+    "mayer_indices"
+  ],
+  "priority": "normal",
+  "description": "A TorsionDrive dataset using geometric.",
+  "dataset_tags": [
+    "openff"
+  ],
+  "compute_tag": "openff",
+  "metadata": {
+    "submitter": "joshua",
+    "creation_date": "2020-10-12",
+    "collection_type": "TorsiondriveDataset",
+    "dataset_name": "TorsionDriveDataset",
+    "short_description": "OpenForcefield TorsionDrives.",
+    "long_description_url": null,
+    "long_description": "A TorsionDrive dataset using geometric.",
+    "elements": []
+  },
+  "provenance": {},
+  "dataset": {},
+  "filtered_molecules": {},
+  "optimization_procedure": {
+    "program": "geometric",
+    "coordsys": "tric",
+    "enforce": 0.1,
+    "epsilon": 0.0,
+    "reset": true,
+    "qccnv": true,
+    "molcnv": false,
+    "check": 0,
+    "trust": 0.1,
+    "tmax": 0.3,
+    "maxiter": 300,
+    "convergence_set": "GAU",
+    "constraints": {}
+  },
+  "grid_spacings": [
+    15
+  ],
+  "energy_upper_limit": 0.05,
+  "dihedral_ranges": null,
+  "energy_decrease_thresh": null
+}


### PR DESCRIPTION
- [ ] Created a new folder in the submissions directory containing the dataset
- [X] Added README.md describing the dataset see [here](https://github.com/openforcefield/qca-dataset-submission/tree/master/submissions/2020-03-26-OpenFF-Gen-2-Torsion-Set-6-supplemental-2) for examples
- [ ] All files used to produce the dataset are included with a description
- [ ] Dataset follows the QCSubmit schema defined for [Datasets](https://github.com/openforcefield/qcsubmit/blob/56680a7d3298b5d8962edcb840b0fdb34558c053/qcsubmit/datasets.py#L340), [OptimizationDatasets](https://github.com/openforcefield/qcsubmit/blob/56680a7d3298b5d8962edcb840b0fdb34558c053/qcsubmit/datasets.py#L1062) and [TorsionDriveDatasets](https://github.com/openforcefield/qcsubmit/blob/56680a7d3298b5d8962edcb840b0fdb34558c053/qcsubmit/datasets.py#L1225)
- [ ] Dataset is named `dataset.json`
- [ ] A PDF depicting the molecules is attached, in the case of torsiondrives this should include the highlighting of the central bond, this can be done automatically using [qcsubmit](https://github.com/openforcefield/qcsubmit/blob/56680a7d3298b5d8962edcb840b0fdb34558c053/qcsubmit/datasets.py#L854). 
- [x] QCSubmit validation passed
- [x] Ready to submit!

This PR adds an xtb compute JSON which expands the fragmented benchmark ligands set. 