### PR TITLE
Pinning ambertools to 20.4 for prod envs with MM

### DIFF
--- a/devtools/prod-envs/qcarchive-worker-openff-openmm.yaml
+++ b/devtools/prod-envs/qcarchive-worker-openff-openmm.yaml
@@ -14,6 +14,7 @@ dependencies:
   - openmm =7.4.2
   - openmmforcefields =0.8.0
   - conda-forge::libiconv
+  - ambertools ==20.4
 
   # procedures
   - geometric

--- a/devtools/prod-envs/qcarchive-worker-openff.yaml
+++ b/devtools/prod-envs/qcarchive-worker-openff.yaml
@@ -23,6 +23,7 @@ dependencies:
   - openmm =7.4.2
   - openmmforcefields =0.8.0
   - conda-forge::libiconv
+  - ambertools ==20.4
 
   # ML calculations
   - pytorch =1.6.0


### PR DESCRIPTION
Currently we get the 20.9 `ambertools` conda package for the `qcarchive-worker-openff-openmm` environment, but 17.0 for the `qcarchive-worker-openff` env with "everything".

The pinning added in this PR yields the 17.0 conda package consistently. Confusingly, this appears to still give us the version 20.0 of tools such as `antechamber`. We may desire consistency over anything else here; discussion welcome!