### PR TITLE
[2020-07-27-OpenFF-Benchmark-Ligands] add a new ANI2X spec with more iterations

### DIFF
--- a/submissions/2020-07-27-OpenFF-Benchmark-Ligands/README.md
+++ b/submissions/2020-07-27-OpenFF-Benchmark-Ligands/README.md
@@ -52,6 +52,11 @@ This is a torsiondrive dataset created from the [OpenFF FEP benchmark dataset](h
         - method: ani2x
         - basis: None
         - program: torchani
+    - ani2x-v2:
+        - name: ani2x
+        - method: ani2x
+        - basis: None
+        - program: torchani
     - gfn2xtb:
         - name: gfn2xtb
         - method: gfn2xtb

--- a/submissions/2020-07-27-OpenFF-Benchmark-Ligands/README.md
+++ b/submissions/2020-07-27-OpenFF-Benchmark-Ligands/README.md
@@ -53,7 +53,7 @@ This is a torsiondrive dataset created from the [OpenFF FEP benchmark dataset](h
         - basis: None
         - program: torchani
     - ani2x-v2:
-        - name: ani2x
+        - name: ani2x-v2
         - method: ani2x
         - basis: None
         - program: torchani

--- a/submissions/2020-07-27-OpenFF-Benchmark-Ligands/compute_ani2x_maxiter.json
+++ b/submissions/2020-07-27-OpenFF-Benchmark-Ligands/compute_ani2x_maxiter.json
@@ -1,0 +1,63 @@
+{
+  "qc_specifications": {
+    "ani2x-v2": {
+      "method": "ani2x",
+      "basis": null,
+      "program": "torchani",
+      "spec_name": "ani2x",
+      "spec_description": "ANI2x ML potential. With a higher maxiter.",
+      "store_wavefunction": "none"
+    }
+  },
+  "dataset_name": "OpenFF-benchmark-ligand-fragments-v1.0",
+  "dataset_tagline": "OpenForcefield TorsionDrives.",
+  "dataset_type": "TorsiondriveDataset",
+  "maxiter": 200,
+  "driver": "gradient",
+  "scf_properties": [
+    "dipole",
+    "quadrupole",
+    "wiberg_lowdin_indices",
+    "mayer_indices"
+  ],
+  "priority": "normal",
+  "description": "A TorsionDrive dataset using geometric.",
+  "dataset_tags": [
+    "openff"
+  ],
+  "compute_tag": "openff",
+  "metadata": {
+    "submitter": "joshuahorton",
+    "creation_date": "2020-08-14",
+    "collection_type": "TorsiondriveDataset",
+    "dataset_name": "TorsionDriveDataset",
+    "short_description": "OpenForcefield TorsionDrives.",
+    "long_description_url": null,
+    "long_description": "A TorsionDrive dataset using geometric.",
+    "elements": []
+  },
+  "provenance": {},
+  "dataset": {},
+  "filtered_molecules": {},
+  "optimization_procedure": {
+    "program": "geometric",
+    "coordsys": "tric",
+    "enforce": 0.1,
+    "epsilon": 0.0,
+    "reset": true,
+    "qccnv": true,
+    "molcnv": false,
+    "check": 0,
+    "trust": 0.1,
+    "tmax": 0.3,
+    "maxiter": 3000,
+    "convergence_set": "GAU",
+    "constraints": {}
+  },
+  "grid_spacings": [
+    15
+  ],
+  "energy_upper_limit": 0.05,
+  "dihedral_ranges": null,
+  "energy_decrease_thresh": null
+}

--- a/submissions/2020-07-27-OpenFF-Benchmark-Ligands/compute_ani2x_maxiter.json
+++ b/submissions/2020-07-27-OpenFF-Benchmark-Ligands/compute_ani2x_maxiter.json
@@ -4,7 +4,7 @@
       "method": "ani2x",
       "basis": null,
       "program": "torchani",
-      "spec_name": "ani2x",
+      "spec_name": "ani2x-v2",
       "spec_description": "ANI2x ML potential. With a higher maxiter.",
       "store_wavefunction": "none"
     }
@@ -27,8 +27,8 @@
   ],
   "compute_tag": "openff",
   "metadata": {
-    "submitter": "joshuahorton",
-    "creation_date": "2020-08-14",
+    "submitter": "trevorgokey",
+    "creation_date": "2020-10-30",
     "collection_type": "TorsiondriveDataset",
     "dataset_name": "TorsionDriveDataset",
     "short_description": "OpenForcefield TorsionDrives.",


### PR DESCRIPTION
Adds a new `compute_ani2x_maxiter.json` file with a new ANI2X spec with more iterations. This is in effort to examine if we can get more successful calculations, since the current spec with 300 iterations produced many failures.

Everything in this update is the same otherwise, including molecules, etc.

- [x] Added new compute specification
- [x] Updated README