### PR TITLE
Benchmark ligand ani1x compute

### DIFF
--- a/submissions/2020-07-27-OpenFF-Benchmark-Ligands/README.md
+++ b/submissions/2020-07-27-OpenFF-Benchmark-Ligands/README.md
@@ -57,6 +57,15 @@ This is a torsiondrive dataset created from the [OpenFF FEP benchmark dataset](h
         - method: ani2x
         - basis: None
         - program: torchani
+    - ani1x:
+        - name: ani1x
+        - basis None
+        - program: torchani
+    - ani1ccx:
+        - name: ani1ccx
+        - method: ani1ccx
+        - basis: None
+        - program: torchani
     - gfn2xtb:
         - name: gfn2xtb
         - method: gfn2xtb

--- a/submissions/2020-07-27-OpenFF-Benchmark-Ligands/compute_ani1x_maxiter.json
+++ b/submissions/2020-07-27-OpenFF-Benchmark-Ligands/compute_ani1x_maxiter.json
@@ -6,8 +6,7 @@
       "program": "torchani",
       "spec_name": "ani1x",
       "spec_description": "ANI1x ML potential with a high maxiter of optimizations steps.",
-      "store_wavefunction": "none",
-      "implicit_solvent": null
+      "store_wavefunction": "none"
     },
     "ani1ccx": {
       "method": "ani1ccx",
@@ -15,8 +14,7 @@
       "program": "torchani",
       "spec_name": "ani1ccx",
       "spec_description": "ANI1ccx ML potential with a high maxiter of optimizations steps.",
-      "store_wavefunction": "none",
-      "implicit_solvent": null
+      "store_wavefunction": "none"
     }
   },
   "dataset_name": "OpenFF-benchmark-ligand-fragments-v1.0",

--- a/submissions/2020-07-27-OpenFF-Benchmark-Ligands/compute_ani1x_maxiter.json
+++ b/submissions/2020-07-27-OpenFF-Benchmark-Ligands/compute_ani1x_maxiter.json
@@ -1,0 +1,73 @@
+{
+  "qc_specifications": {
+    "ani1x": {
+      "method": "ani1x",
+      "basis": null,
+      "program": "torchani",
+      "spec_name": "ani1x",
+      "spec_description": "ANI1x ML potential with a high maxiter of optimizations steps.",
+      "store_wavefunction": "none",
+      "implicit_solvent": null
+    },
+    "ani1ccx": {
+      "method": "ani1ccx",
+      "basis": null,
+      "program": "torchani",
+      "spec_name": "ani1ccx",
+      "spec_description": "ANI1ccx ML potential with a high maxiter of optimizations steps.",
+      "store_wavefunction": "none",
+      "implicit_solvent": null
+    }
+  },
+  "dataset_name": "OpenFF-benchmark-ligand-fragments-v1.0",
+  "dataset_tagline": "OpenForcefield TorsionDrives.",
+  "dataset_type": "TorsiondriveDataset",
+  "maxiter": 200,
+  "driver": "gradient",
+  "scf_properties": [
+    "dipole",
+    "quadrupole",
+    "wiberg_lowdin_indices",
+    "mayer_indices"
+  ],
+  "priority": "normal",
+  "description": "A TorsionDrive dataset using geometric.",
+  "dataset_tags": [
+    "openff"
+  ],
+  "compute_tag": "openff",
+  "metadata": {
+    "submitter": "JTHorton",
+    "creation_date": "2020-11-03",
+    "collection_type": "TorsiondriveDataset",
+    "dataset_name": "OpenFF-benchmark-ligand-fragments-v1.0",
+    "short_description": "OpenForcefield TorsionDrives.",
+    "long_description_url": null,
+    "long_description": "A TorsionDrive dataset using geometric.",
+    "elements": []
+  },
+  "provenance": {},
+  "dataset": {},
+  "filtered_molecules": {},
+  "optimization_procedure": {
+    "program": "geometric",
+    "coordsys": "tric",
+    "enforce": 0.1,
+    "epsilon": 0.0,
+    "reset": true,
+    "qccnv": true,
+    "molcnv": false,
+    "check": 0,
+    "trust": 0.1,
+    "tmax": 0.3,
+    "maxiter": 3000,
+    "convergence_set": "GAU",
+    "constraints": {}
+  },
+  "grid_spacings": [
+    15
+  ],
+  "energy_upper_limit": 0.05,
+  "dihedral_ranges": null,
+  "energy_decrease_thresh": null
+}


### PR DESCRIPTION
- [x] Added README.md describing the dataset see [here](https://github.com/openforcefield/qca-dataset-submission/tree/master/submissions/2020-03-26-OpenFF-Gen-2-Torsion-Set-6-supplemental-2) for examples
- [ ] QCSubmit validation passed
- [ ] Ready to submit!

This adds compute to the benchmark ligand fragments torsiondrives for ani1x and ani1ccx with a high maxiter. Due to the restricted coverage of ani1x I expect the maximum number of torsiondrives which we can complete to be 246/481.