### PR TITLE
[prod-env-pin-update] Updated production env package pins for qcfractal 0.15.1

### DIFF
--- a/devtools/prod-envs/qcarchive-worker-openff-ani.yaml
+++ b/devtools/prod-envs/qcarchive-worker-openff-ani.yaml
@@ -6,11 +6,11 @@ channels:
 dependencies:
   - python =3.7
   - pip
-  - qcfractal =0.14.0
+  - qcfractal =0.15.1
   - qcengine =0.17.0
 
   # ML calculations
-  - pytorch =1.6.0
+  - pytorch =1.7.0
 
   # procedures
   - geometric

--- a/devtools/prod-envs/qcarchive-worker-openff-openmm.yaml
+++ b/devtools/prod-envs/qcarchive-worker-openff-openmm.yaml
@@ -5,12 +5,12 @@ channels:
   - defaults
 dependencies:
   - python =3.7
-  - qcfractal =0.14.0
+  - qcfractal =0.15.1
   - qcengine =0.17.0
     
   # MM calculations
-  - openforcefield =0.7.2
-  - openforcefields =1.2.1
+  - openforcefield =0.8.0
+  - openforcefields =1.3.0
   - openmm =7.4.2
   - openmmforcefields =0.8.0
   - conda-forge::libiconv

--- a/devtools/prod-envs/qcarchive-worker-openff-psi4.yaml
+++ b/devtools/prod-envs/qcarchive-worker-openff-psi4.yaml
@@ -9,7 +9,7 @@ dependencies:
   - qcengine =0.17.0
 
   # QM calculations
-  - psi4 =1.4a2.dev723+fb499f4
+  - psi4 =1.4a2.dev1058+670a850
   - dftd3
   - gcp
     

--- a/devtools/prod-envs/qcarchive-worker-openff-psi4.yaml
+++ b/devtools/prod-envs/qcarchive-worker-openff-psi4.yaml
@@ -5,7 +5,7 @@ channels:
   - defaults
 dependencies:
   - python =3.7
-  - qcfractal =0.14.0
+  - qcfractal =0.15.1
   - qcengine =0.17.0
 
   # QM calculations

--- a/devtools/prod-envs/qcarchive-worker-openff-xtb.yaml
+++ b/devtools/prod-envs/qcarchive-worker-openff-xtb.yaml
@@ -5,11 +5,11 @@ channels:
   - defaults
 dependencies:
   - python =3.7
-  - qcfractal =0.14.0
+  - qcfractal =0.15.1
   - qcengine =0.17.0
 
   # QM calculations
-  - xtb-python =20.1
+  - xtb-python =20.2
   - dftd3
   - gcp
     

--- a/devtools/prod-envs/qcarchive-worker-openff.yaml
+++ b/devtools/prod-envs/qcarchive-worker-openff.yaml
@@ -8,25 +8,25 @@ channels:
 dependencies:
   - python =3.7
   - pip
-  - qcfractal =0.14.0
+  - qcfractal =0.15.1
   - qcengine =0.17.0
 
   # QM calculations
   - psi4 =1.4a2.dev723+fb499f4
-  - xtb-python =20.1
+  - xtb-python =20.2
   - dftd3
   - gcp
     
   # MM calculations
-  - openforcefield =0.7.2
-  - openforcefields =1.2.1
+  - openforcefield =0.8.0
+  - openforcefields =1.3.0
   - openmm =7.4.2
   - openmmforcefields =0.8.0
   - conda-forge::libiconv
   - ambertools ==20.4
 
   # ML calculations
-  - pytorch =1.6.0
+  - pytorch =1.7.0
 
   # procedures
   - geometric

--- a/devtools/prod-envs/qcarchive-worker-openff.yaml
+++ b/devtools/prod-envs/qcarchive-worker-openff.yaml
@@ -12,7 +12,7 @@ dependencies:
   - qcengine =0.17.0
 
   # QM calculations
-  - psi4 =1.4a2.dev723+fb499f4
+  - psi4 =1.4a2.dev1058+670a850
   - xtb-python =20.2
   - dftd3
   - gcp


### PR DESCRIPTION
I updated pins for all packages to latest released versions, except ambertools (left pinned at 20.4; #149).

We need a recommendation on which `linux-64` conda package to pin to for `psi4`: https://anaconda.org/psi4/psi4/files