### PR TITLE
Downgrading pytorch from 1.7.0 to 1.6.0 for prod envs

### DIFF
--- a/devtools/prod-envs/qcarchive-worker-openff-ani.yaml
+++ b/devtools/prod-envs/qcarchive-worker-openff-ani.yaml
@@ -10,7 +10,7 @@ dependencies:
   - qcengine =0.17.0
 
   # ML calculations
-  - pytorch =1.6.0
+  - pytorch =1.6.0        # before upgrading, check interactions with other packages
 
   # procedures
   - geometric

--- a/devtools/prod-envs/qcarchive-worker-openff-ani.yaml
+++ b/devtools/prod-envs/qcarchive-worker-openff-ani.yaml
@@ -10,7 +10,7 @@ dependencies:
   - qcengine =0.17.0
 
   # ML calculations
-  - pytorch =1.7.0
+  - pytorch =1.6.0
 
   # procedures
   - geometric

--- a/devtools/prod-envs/qcarchive-worker-openff.yaml
+++ b/devtools/prod-envs/qcarchive-worker-openff.yaml
@@ -26,7 +26,7 @@ dependencies:
   - ambertools ==20.4
 
   # ML calculations
-  - pytorch =1.7.0
+  - pytorch =1.6.0
 
   # procedures
   - geometric

--- a/devtools/prod-envs/qcarchive-worker-openff.yaml
+++ b/devtools/prod-envs/qcarchive-worker-openff.yaml
@@ -26,7 +26,7 @@ dependencies:
   - ambertools ==20.4
 
   # ML calculations
-  - pytorch =1.6.0
+  - pytorch =1.6.0        # before upgrading, check interactions with other packages
 
   # procedures
   - geometric


### PR DESCRIPTION
Latest pytorch can break e.g. psi4 due to requiring a substitute `dataclasses` package for the standard lib one. Using 1.6.0 doesn't do this.