### PR TITLE
MM compute for OpenFF Substituted Phenyl Set 1 v2.0 - reroll

### DIFF
--- a/submissions/2020-10-06-OpenFF-Phenyl-Set/README.md
+++ b/submissions/2020-10-06-OpenFF-Phenyl-Set/README.md
@@ -52,3 +52,29 @@ Extracting original molecules, conformers, and CMILES information; generating QC
       method: B3LYP-D3BJ
       basis: DZVP
       program: psi4
+
+
+## Supplemental compute specs
+
+- scf properties:
+    - `dipole`
+    - `quadrupole`
+    - `wiberg_lowdin_indices`
+    - `mayer_indices`
+- qc spec
+    - name: openff-1.0.0
+      method: openff-1.0.0
+      basis: smirnoff
+      program: openmm
+    - name: openff-1.2.1
+      method: openff-1.2.1
+      basis: smirnoff
+      program: openmm
+    - name: openff-1.3.0
+      method: openff-1.3.0
+      basis: smirnoff
+      program: openmm
+    - name: gaff-2.11
+      method: gaff-2.11
+      basis: antechamber
+      program: openmm

--- a/submissions/2020-10-06-OpenFF-Phenyl-Set/compute.json
+++ b/submissions/2020-10-06-OpenFF-Phenyl-Set/compute.json
@@ -1,0 +1,87 @@
+{
+  "qc_specifications": {
+    "openff-1.0.0": {
+      "method": "openff-1.0.0",
+      "basis": "smirnoff",
+      "program": "openmm",
+      "spec_name": "openff-1.0.0",
+      "spec_description": "default openff-1.0.0 spec",
+      "store_wavefunction": "none"
+    },
+    "openff-1.2.1": {
+      "method": "openff-1.2.1",
+      "basis": "smirnoff",
+      "program": "openmm",
+      "spec_name": "openff-1.2.1",
+      "spec_description": "default openff-1.2.1 spec",
+      "store_wavefunction": "none"
+    },
+    "openff-1.3.0": {
+      "method": "openff-1.3.0",
+      "basis": "smirnoff",
+      "program": "openmm",
+      "spec_name": "openff-1.3.0",
+      "spec_description": "default openff-1.3.0 spec",
+      "store_wavefunction": "none"
+    },
+    "gaff-2.11": {
+      "method": "gaff-2.11",
+      "basis": "antechamber",
+      "program": "openmm",
+      "spec_name": "gaff-2.11",
+      "spec_description": "default gaff-2.11 spec",
+      "store_wavefunction": "none"
+    }
+  },
+  "dataset_name": "OpenFF Substituted Phenyl Set 1 v2.0",
+  "dataset_tagline": "OpenForcefield TorsionDrives.",
+  "dataset_type": "TorsiondriveDataset",
+  "maxiter": 200,
+  "driver": "gradient",
+  "scf_properties": [
+    "dipole",
+    "quadrupole",
+    "wiberg_lowdin_indices",
+    "mayer_indices"
+  ],
+  "priority": "normal",
+  "description": "A TorsionDrive dataset using geometric.",
+  "dataset_tags": [
+    "openff"
+  ],
+  "compute_tag": "openff",
+  "metadata": {
+    "submitter": "dotsdl",
+    "creation_date": "2020-11-11",
+    "collection_type": "TorsiondriveDataset",
+    "dataset_name": "OpenFF Substituted Phenyl Set 1 v2.0",
+    "short_description": "Torsiondrives for selected dihedrals of various phenyl fragments",
+    "long_description_url": "https://github.com/openforcefield/qca-dataset-submission/tree/master/submissions/2020-10-06-OpenFF-Phenyl-Set",
+    "long_description": "Torsiondrives for selected dihedrals of various phenyl fragments",
+    "elements": []
+  },
+  "provenance": {},
+  "dataset": {},
+  "filtered_molecules": {},
+  "optimization_procedure": {
+    "program": "geometric",
+    "coordsys": "tric",
+    "enforce": 0.1,
+    "epsilon": 0.0,
+    "reset": true,
+    "qccnv": true,
+    "molcnv": false,
+    "check": 0,
+    "trust": 0.1,
+    "tmax": 0.3,
+    "maxiter": 300,
+    "convergence_set": "GAU",
+    "constraints": {}
+  },
+  "grid_spacings": [
+    15
+  ],
+  "energy_upper_limit": 0.05,
+  "dihedral_ranges": null,
+  "energy_decrease_thresh": null
+}


### PR DESCRIPTION
This PR is a re-do of #161; because I squash merged that PR's base, it wasn't possible to merge `master` back into it without a mess.

- [ ] Created a new folder in the submissions directory containing the dataset
- [ ] Added README.md describing the dataset see [here](https://github.com/openforcefield/qca-dataset-submission/tree/master/submissions/2020-03-26-OpenFF-Gen-2-Torsion-Set-6-supplemental-2) for examples
- [ ] All files used to produce the dataset are included with a description
- [ ] Dataset follows the QCSubmit schema defined for [Datasets](https://github.com/openforcefield/qcsubmit/blob/56680a7d3298b5d8962edcb840b0fdb34558c053/qcsubmit/datasets.py#L340), [OptimizationDatasets](https://github.com/openforcefield/qcsubmit/blob/56680a7d3298b5d8962edcb840b0fdb34558c053/qcsubmit/datasets.py#L1062) and [TorsionDriveDatasets](https://github.com/openforcefield/qcsubmit/blob/56680a7d3298b5d8962edcb840b0fdb34558c053/qcsubmit/datasets.py#L1225)
- [ ] Dataset is named `dataset.json`
- [ ] A PDF depicting the molecules is attached, in the case of torsiondrives this should include the highlighting of the central bond, this can be done automatically using [qcsubmit](https://github.com/openforcefield/qcsubmit/blob/56680a7d3298b5d8962edcb840b0fdb34558c053/qcsubmit/datasets.py#L854). 
- [ ] QCSubmit validation passed
- [ ] Ready to submit!