### PR TITLE
Update to the new qcsubmit conda package.

### DIFF
--- a/devtools/conda-envs/error-cycle.yaml
+++ b/devtools/conda-envs/error-cycle.yaml
@@ -10,7 +10,7 @@ dependencies:
   - python
   - pip
   - qcportal
-  - qcsubmit==v0.1.0
+  - qcsubmit==0.1.1
   - pip:
       - PyGithub
       - pandas

--- a/devtools/conda-envs/queued-submit.yaml
+++ b/devtools/conda-envs/queued-submit.yaml
@@ -11,7 +11,7 @@ dependencies:
   - python
   - pip
   - qcportal
-  - qcsubmit==v0.1.0
+  - qcsubmit==0.1.1
   - pip:
 #      - basis_set_exchange
       - PyGithub

--- a/devtools/conda-envs/validation.yaml
+++ b/devtools/conda-envs/validation.yaml
@@ -11,7 +11,7 @@ dependencies:
   - python
   - pip
 
-  - qcsubmit==v0.1.0
+  - qcsubmit==0.1.1
   - PyGithub
   - pandas
   - tabulate


### PR DESCRIPTION
Update to the new qcsubmit conda package which should fix errors when we try to add specifications which are already present in a dataset.