### PR TITLE
[PEPCONF] Add WB97X/6-31G* QC spec

### DIFF
--- a/submissions/2020-10-26-PEPCONF-Optimization/README.md
+++ b/submissions/2020-10-26-PEPCONF-Optimization/README.md
@@ -49,6 +49,11 @@ Generating stereoisomers, conformers, and QCSubmit dataset:
     - `wiberg_lowdin_indices`
     - `mayer_indices`
 - qc spec
-    - name: default
-    - method: B3LYP-D3BJ
-    - basis: DZVP
+    - default
+        - method: B3LYP-D3BJ
+        - basis: DZVP
+        - program: psi4
+    - ani2x-qm
+        - method: WB97X
+        - basis: 6-31G*
+        - program: psi4

--- a/submissions/2020-10-26-PEPCONF-Optimization/compute.json
+++ b/submissions/2020-10-26-PEPCONF-Optimization/compute.json
@@ -1,10 +1,10 @@
 {
   "qc_specifications": {
-    "default": {
+    "ani2x-qm": {
       "method": "WB97X",
       "basis": "6-31G*",
       "program": "psi4",
-      "spec_name": "ANI-2x-QM",
+      "spec_name": "ani2x-qm",
       "spec_description": "QM optimization using the method/basis on which ANI2x is trained",
       "store_wavefunction": "none",
       "implicit_solvent": null

--- a/submissions/2020-10-26-PEPCONF-Optimization/compute.json
+++ b/submissions/2020-10-26-PEPCONF-Optimization/compute.json
@@ -1,0 +1,64 @@
+{
+  "qc_specifications": {
+    "default": {
+      "method": "WB97X",
+      "basis": "6-31G*",
+      "program": "psi4",
+      "spec_name": "ANI-2x-QM",
+      "spec_description": "QM optimization using the method/basis on which ANI2x is trained",
+      "store_wavefunction": "none",
+      "implicit_solvent": null
+    }
+  },
+  "dataset_name": "OpenFF PEPCONF OptimizationDataset v1.0",
+  "dataset_tagline": "OptimizationDataset of short peptides in various contexts, including disulfide bridges.",
+  "dataset_type": "OptimizationDataset",
+  "maxiter": 200,
+  "driver": "gradient",
+  "scf_properties": [
+    "dipole",
+    "quadrupole",
+    "wiberg_lowdin_indices",
+    "mayer_indices"
+  ],
+  "priority": "normal",
+  "description": "OptimizationDataset of short peptides in various contexts, including disulfide bridges.",
+  "dataset_tags": [
+    "openff"
+  ],
+  "compute_tag": "openff",
+  "metadata": {
+    "submitter": "jchodera",
+    "creation_date": "2020-11-08",
+    "collection_type": "OptimizationDataset",
+    "dataset_name": "OpenFF PEPCONF OptimizationDataset v1.0",
+    "short_description": "OptimizationDataset of short peptides in various contexts, including disulfide bridges.",
+    "long_description_url": "https://github.com/openforcefield/qca-dataset-submission/tree/master/submissions/2020-10-26-PEPCONF-Optimization",
+    "long_description": "OptimizationDataset of short peptides in various contexts, including disulfide bridges. The source PEPCONF dataset is documented in [Nature Scientific Data](https://www.nature.com/articles/sdata2018310), and available on [GitHub](https://github.com/aoterodelaroza/pepconf). This dataset extracts the molecules that were simulated, but uses the QCSubmit infrastructure to generate a new `OptimizationDataset`, so does not use the original conformers.",
+    "elements": [
+      "S",
+      "O",
+      "N",
+      "C",
+      "H"
+    ]
+  },
+  "provenance": {},
+  "dataset": {},
+  "filtered_molecules": {},
+  "optimization_procedure": {
+    "program": "geometric",
+    "coordsys": "tric",
+    "enforce": 0.0,
+    "epsilon": 1e-05,
+    "reset": false,
+    "qccnv": false,
+    "molcnv": false,
+    "check": 0,
+    "trust": 0.1,
+    "tmax": 0.3,
+    "maxiter": 300,
+    "convergence_set": "GAU",
+    "constraints": {}
+  }
+}


### PR DESCRIPTION
- [ ] Created a new folder in the submissions directory containing the dataset
- [x] Added README.md describing the dataset see [here](https://github.com/openforcefield/qca-dataset-submission/tree/master/submissions/2020-03-26-OpenFF-Gen-2-Torsion-Set-6-supplemental-2) for examples
- [x] All files used to produce the dataset are included with a description
- [x] Dataset follows the QCSubmit schema defined for [Datasets](https://github.com/openforcefield/qcsubmit/blob/56680a7d3298b5d8962edcb840b0fdb34558c053/qcsubmit/datasets.py#L340), [OptimizationDatasets](https://github.com/openforcefield/qcsubmit/blob/56680a7d3298b5d8962edcb840b0fdb34558c053/qcsubmit/datasets.py#L1062) and [TorsionDriveDatasets](https://github.com/openforcefield/qcsubmit/blob/56680a7d3298b5d8962edcb840b0fdb34558c053/qcsubmit/datasets.py#L1225)
- [ ] Dataset is named `dataset.json`
- [ ] A PDF depicting the molecules is attached, in the case of torsiondrives this should include the highlighting of the central bond, this can be done automatically using [qcsubmit](https://github.com/openforcefield/qcsubmit/blob/56680a7d3298b5d8962edcb840b0fdb34558c053/qcsubmit/datasets.py#L854). 
- [x] QCSubmit validation passed
- [x] Ready to submit!