### PR TITLE
Updates to prod-envs, GHA conda envs

### DIFF
--- a/devtools/conda-envs/error-cycle.yaml
+++ b/devtools/conda-envs/error-cycle.yaml
@@ -10,7 +10,7 @@ dependencies:
   - python
   - pip
   - qcportal
-  - qcsubmit==0.1.1
+  - openff-qcsubmit =0.2.0
   - pip:
       - PyGithub
       - pandas

--- a/devtools/conda-envs/queued-submit.yaml
+++ b/devtools/conda-envs/queued-submit.yaml
@@ -11,7 +11,7 @@ dependencies:
   - python
   - pip
   - qcportal
-  - qcsubmit==0.1.1
+  - openff-qcsubmit =0.2.0
   - pip:
 #      - basis_set_exchange
       - PyGithub

--- a/devtools/conda-envs/validation.yaml
+++ b/devtools/conda-envs/validation.yaml
@@ -11,7 +11,7 @@ dependencies:
   - python
   - pip
 
-  - qcsubmit==0.1.1
+  - openff-qcsubmit =0.2.0
   - PyGithub
   - pandas
   - tabulate

--- a/devtools/prod-envs/qcarchive-worker-openff-ani.yaml
+++ b/devtools/prod-envs/qcarchive-worker-openff-ani.yaml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - python =3.7
   - pip
-  - qcfractal =0.15.1
+  - qcfractal =0.15.2
   - qcengine =0.17.0
 
   # ML calculations

--- a/devtools/prod-envs/qcarchive-worker-openff-openmm.yaml
+++ b/devtools/prod-envs/qcarchive-worker-openff-openmm.yaml
@@ -5,13 +5,13 @@ channels:
   - defaults
 dependencies:
   - python =3.7
-  - qcfractal =0.15.1
+  - qcfractal =0.15.2
   - qcengine =0.17.0
     
   # MM calculations
-  - openforcefield =0.8.0
+  - openforcefield =0.8.3
   - openforcefields =1.3.0
-  - openmm =7.4.2
+  - openmm =7.5.0
   - openmmforcefields =0.8.0
   - conda-forge::libiconv
   - ambertools ==20.4

--- a/devtools/prod-envs/qcarchive-worker-openff-psi4.yaml
+++ b/devtools/prod-envs/qcarchive-worker-openff-psi4.yaml
@@ -12,6 +12,7 @@ dependencies:
   - psi4 =1.4a2.dev1058+670a850
   - dftd3
   - gcp
+  - gau2grid =2.0.3
     
   # procedures
   - geometric

--- a/devtools/prod-envs/qcarchive-worker-openff-psi4.yaml
+++ b/devtools/prod-envs/qcarchive-worker-openff-psi4.yaml
@@ -9,7 +9,7 @@ dependencies:
   - qcengine =0.17.0
 
   # QM calculations
-  - psi4 =1.4a2.dev1058+670a850
+  - psi4 =1.4a3.dev26+51d7763
   - dftd3
   - gcp
   - gau2grid =2.0.3

--- a/devtools/prod-envs/qcarchive-worker-openff-psi4.yaml
+++ b/devtools/prod-envs/qcarchive-worker-openff-psi4.yaml
@@ -5,7 +5,7 @@ channels:
   - defaults
 dependencies:
   - python =3.7
-  - qcfractal =0.15.1
+  - qcfractal =0.15.2
   - qcengine =0.17.0
 
   # QM calculations

--- a/devtools/prod-envs/qcarchive-worker-openff-xtb.yaml
+++ b/devtools/prod-envs/qcarchive-worker-openff-xtb.yaml
@@ -5,7 +5,7 @@ channels:
   - defaults
 dependencies:
   - python =3.7
-  - qcfractal =0.15.1
+  - qcfractal =0.15.2
   - qcengine =0.17.0
 
   # QM calculations

--- a/devtools/prod-envs/qcarchive-worker-openff.yaml
+++ b/devtools/prod-envs/qcarchive-worker-openff.yaml
@@ -16,6 +16,7 @@ dependencies:
   - xtb-python =20.2
   - dftd3
   - gcp
+  - gau2grid =2.0.3
     
   # MM calculations
   - openforcefield =0.8.3

--- a/devtools/prod-envs/qcarchive-worker-openff.yaml
+++ b/devtools/prod-envs/qcarchive-worker-openff.yaml
@@ -12,7 +12,7 @@ dependencies:
   - qcengine =0.17.0
 
   # QM calculations
-  - psi4 =1.4a2.dev1058+670a850
+  - psi4 =1.4a3.dev26+51d7763
   - xtb-python =20.2
   - dftd3
   - gcp

--- a/devtools/prod-envs/qcarchive-worker-openff.yaml
+++ b/devtools/prod-envs/qcarchive-worker-openff.yaml
@@ -8,7 +8,7 @@ channels:
 dependencies:
   - python =3.7
   - pip
-  - qcfractal =0.15.1
+  - qcfractal =0.15.2
   - qcengine =0.17.0
 
   # QM calculations
@@ -18,9 +18,9 @@ dependencies:
   - gcp
     
   # MM calculations
-  - openforcefield =0.8.0
+  - openforcefield =0.8.3
   - openforcefields =1.3.0
-  - openmm =7.4.2
+  - openmm =7.5.0
   - openmmforcefields =0.8.0
   - conda-forge::libiconv
   - ambertools ==20.4


### PR DESCRIPTION
Updated the following packages across all environments:
- qcsubmit=0.1.1 -> openff-qcsubmit=0.2.0
- qcfractal=0.15.1 -> 0.15.2
- openforcefield=0.8.0 -> 0.8.3
- openmm=7.4.2 -> 7.5.0

Added to prod envs with psi4:
- gau2grid=2.0.3

Leaving in place, despite possible package updates (discuss):
- ambertools=20.4
- psi4=1.4a2.dev1058+670a850