### PR TITLE
Added qcarchive-user-submit production environment

### DIFF
--- a/devtools/prod-envs/qcarchive-user-submit.yaml
+++ b/devtools/prod-envs/qcarchive-user-submit.yaml
@@ -1,4 +1,4 @@
-name: queued-submit
+name: qcarchive-user-submit
 
 channels:
   - conda-forge


### PR DESCRIPTION
Moved @pavankum's user submission environment to `prod-envs`, denoting it as a production resource. This is designed as a standard starting environment for preparing submissions, which we maintain to keep pins up-to-date with current practice and packages.