### PR TITLE
Added MM compute expansion for OpenFF Industry Benchmark Season 1 v1.1

### DIFF
--- a/submissions/2021-06-04-OpenFF-Industry-Benchmark-Season-1-v1.1/compute.json
+++ b/submissions/2021-06-04-OpenFF-Industry-Benchmark-Season-1-v1.1/compute.json
@@ -1,0 +1,118 @@
+{
+  "qc_specifications": {
+    "smirnoff99Frosst-1.1.0": {
+         "method": "smirnoff99Frosst-1.1.0",
+         "basis": "smirnoff",
+         "program": "openmm",
+         "spec_name": "smirnoff99Frosst-1.1.0",
+         "spec_description": "default smirnoff99Frosst-1.1.0 optimization spec",
+         "store_wavefunction": "none",
+         "implicit_solvent": null
+    },
+    "openff-1.0.0": {
+         "method": "openff-1.0.0",
+         "basis": "smirnoff",
+         "program": "openmm",
+         "spec_name": "openff-1.0.0",
+         "spec_description": "default openff-1.0.0 optimization spec",
+         "store_wavefunction": "none",
+         "implicit_solvent": null
+    },
+    "openff-1.1.1": {
+         "method": "openff-1.1.1",
+         "basis": "smirnoff",
+         "program": "openmm",
+         "spec_name": "openff-1.1.1",
+         "spec_description": "default openff-1.1.1 optimization spec",
+         "store_wavefunction": "none",
+         "implicit_solvent": null
+    },
+    "openff-1.2.1": {
+         "method": "openff-1.2.1",
+         "basis": "smirnoff",
+         "program": "openmm",
+         "spec_name": "openff-1.2.1",
+         "spec_description": "default openff-1.2.1 optimization spec",
+         "store_wavefunction": "none",
+         "implicit_solvent": null
+    },
+    "openff-1.3.0": {
+         "method": "openff-1.3.0",
+         "basis": "smirnoff",
+         "program": "openmm",
+         "spec_name": "openff-1.3.0",
+         "spec_description": "default openff-1.3.0 optimization spec",
+         "store_wavefunction": "none",
+         "implicit_solvent": null
+    },
+    "gaff-2.11": {
+         "method": "gaff-2.11",
+         "basis": "antechamber",
+         "program": "openmm",
+         "spec_name": "gaff-2.11",
+         "spec_description": "default gaff-2.11 optimization spec",
+         "store_wavefunction": "none",
+         "implicit_solvent": null
+    }             
+  },
+  "maxiter": 200,
+  "driver": "gradient",
+  "scf_properties": [
+    "dipole",
+    "quadrupole",
+    "wiberg_lowdin_indices",
+    "mayer_indices"
+  ],
+  "priority": "normal",
+  "dataset_tags": [
+    "openff"
+  ],
+  "compute_tag": "openff",
+  "dataset_name": "OpenFF Industry Benchmark Season 1 v1.1",
+  "dataset_tagline": "The public molecules from the OpenFF Industry Benchmark.",
+  "dataset_type": "OptimizationDataset",
+  "description": "The combination of all publicly chossen compound sets by industry partners from the OpenFF season 1 industry benchmark.",
+  "metadata": {
+    "submitter": "dotsdl",
+    "creation_date": "2021-06-04",
+    "collection_type": "OptimizationDataset",
+    "dataset_name": "OpenFF Industry Benchmark Season 1 v1.1",
+    "short_description": "The public molecules from the OpenFF Industry Benchmark.",
+    "long_description_url": "https://github.com/openforcefield/qca-dataset-submission/tree/master/submissions/2021-06-04-OpenFF-Industry-Benchmark-Season-1-v1.1",
+    "long_description": "The combination of all publicly chosen compound sets by industry partners from the OpenFF season 1 industry benchmark.",
+    "elements": [
+      "Br",
+      "F",
+      "P",
+      "H",
+      "N",
+      "S",
+      "Cl",
+      "O",
+      "C"
+    ]
+  },
+  "provenance": {
+    "openff-qcsubmit": "0.2.1",
+    "openff-toolkit": "0.8.4",
+    "rdkit": "2021.03.2",
+    "openff-benchmark": "2021.03.17.0"
+  },
+  "dataset": {},
+  "filtered_molecules": {},
+  "optimization_procedure": {
+    "program": "geometric",
+    "coordsys": "dlc",
+    "enforce": 0.0,
+    "epsilon": 1e-05,
+    "reset": true,
+    "qccnv": false,
+    "molcnv": false,
+    "check": 0,
+    "trust": 0.1,
+    "tmax": 0.3,
+    "maxiter": 300,
+    "convergence_set": "GAU",
+    "constraints": {}
+  }
+}


### PR DESCRIPTION
<!-- Choose the checklist below based on the type of PR this is -->
<!-- Delete all other checklists -->

## Compute Expansion Checklist

- [x] Compute expansion filename matches pattern `compute*.json`; may feature a compression extension, such as `.bz2`
- [x] QCSubmit validation passed
- [x] Ready to submit!
