### PR TITLE
added a compute spec, wB97X-D3BJ/dzvp to the the theory benchmark tor…

### DIFF
--- a/submissions/2020-12-18-OpenFF-Theory-Benchmarking-Set-v1.0/compute.json
+++ b/submissions/2020-12-18-OpenFF-Theory-Benchmarking-Set-v1.0/compute.json
@@ -5,7 +5,7 @@
       "basis": "DZVP",
       "program": "psi4",
       "spec_name": "default",
-      "spec_description": "Standard OpenFF optimization quantum chemistry specification.",
+      "spec_description": "A torsiondrive dataset for benchmarking WB97X-D3BJ",
       "store_wavefunction": "none",
       "implicit_solvent": null
     }
@@ -47,9 +47,9 @@
     ]
   },
   "provenance": {
-    "qcsubmit": "0.1.1+14.ga6eec90",
-    "openforcefield": "0.8.0",
-    "openeye": "2019.Oct.2"
+    "qcsubmit": "0.2.1",
+    "openforcefield": "0.8.4",
+    "rdkit": "2021.03.3"
   },
   "dataset": {},
   "filtered_molecules": {},

--- a/submissions/2020-12-18-OpenFF-Theory-Benchmarking-Set-v1.0/compute.json
+++ b/submissions/2020-12-18-OpenFF-Theory-Benchmarking-Set-v1.0/compute.json
@@ -1,0 +1,77 @@
+{
+  "qc_specifications": {
+    "default": {
+      "method": "WB97X-D3BJ",
+      "basis": "DZVP",
+      "program": "psi4",
+      "spec_name": "default",
+      "spec_description": "Standard OpenFF optimization quantum chemistry specification.",
+      "store_wavefunction": "none",
+      "implicit_solvent": null
+    }
+  },
+  "dataset_name": "OpenFF Theory Benchmarking Set v1.0",
+  "dataset_tagline": "Torsiondrives for theory benchmarking",
+  "dataset_type": "TorsiondriveDataset",
+  "maxiter": 200,
+  "driver": "gradient",
+  "scf_properties": [
+    "dipole",
+    "quadrupole",
+    "wiberg_lowdin_indices",
+    "mayer_indices"
+  ],
+  "priority": "normal",
+  "description": "A torsiondrive dataset for theory benchmarking",
+  "dataset_tags": [
+    "openff"
+  ],
+  "compute_tag": "openff",
+  "metadata": {
+    "submitter": "pavankum",
+    "creation_date": "2021-06-16",
+    "collection_type": "TorsiondriveDataset",
+    "dataset_name": "OpenFF Theory Benchmarking Set v1.0",
+    "short_description": "Torsiondrives for theory benchmarking",
+    "long_description_url": "https://github.com/openforcefield/qca-dataset-submission/tree/master/submissions/2020-12-18-OpenFF-Theory-Benchmarking-Set-v1.0",
+    "long_description": "Adding wB97X-D3BJ compute spec to the torsiondrive dataset for theory benchmarking",
+    "elements": [
+      "O",
+      "N",
+      "F",
+      "P",
+      "H",
+      "S",
+      "C",
+      "Cl"
+    ]
+  },
+  "provenance": {
+    "qcsubmit": "0.1.1+14.ga6eec90",
+    "openforcefield": "0.8.0",
+    "openeye": "2019.Oct.2"
+  },
+  "dataset": {},
+  "filtered_molecules": {},
+  "optimization_procedure": {
+    "program": "geometric",
+    "coordsys": "tric",
+    "enforce": 0.1,
+    "epsilon": 0.0,
+    "reset": true,
+    "qccnv": true,
+    "molcnv": false,
+    "check": 0,
+    "trust": 0.1,
+    "tmax": 0.3,
+    "maxiter": 300,
+    "convergence_set": "GAU",
+    "constraints": {}
+  },
+  "grid_spacing": [
+    15
+  ],
+  "energy_upper_limit": 0.05,
+  "dihedral_ranges": null,
+  "energy_decrease_thresh": null
+}

--- a/submissions/2020-12-18-OpenFF-Theory-Benchmarking-Set-v1.0/compute.json
+++ b/submissions/2020-12-18-OpenFF-Theory-Benchmarking-Set-v1.0/compute.json
@@ -1,6 +1,6 @@
 {
   "qc_specifications": {
-    "default": {
+    "WB97X-D3BJ": {
       "method": "WB97X-D3BJ",
       "basis": "DZVP",
       "program": "psi4",


### PR DESCRIPTION
…siondrives set

<!-- Choose the checklist below based on the type of PR this is -->
<!-- Delete all other checklists -->

## Compute Expansion Checklist

- [x] Compute expansion filename matches pattern `compute*.json`; may feature a compression extension, such as `.bz2`
- [ ] QCSubmit validation passed
- [ ] Ready to submit!
