### PR TITLE
Update to latest `openff-qcsubmit` version

### DIFF
--- a/devtools/conda-envs/error-cycle.yaml
+++ b/devtools/conda-envs/error-cycle.yaml
@@ -2,17 +2,13 @@ name: error-cycle
 
 channels:
   - conda-forge
-  - omnia
   - defaults
-  - omnia/label/rc
-  - omnia/label/benchmark
 
 dependencies:
   - python =3.7
   - pip
   - qcportal
-  - openff-qcsubmit =0.2.1
-  - pip:
-      - PyGithub
-      - pandas
-      - tabulate
+  - openff-qcsubmit =0.2.2
+  - PyGithub
+  - pandas
+  - tabulate

--- a/devtools/conda-envs/queued-submit.yaml
+++ b/devtools/conda-envs/queued-submit.yaml
@@ -2,19 +2,13 @@ name: queued-submit
 
 channels:
   - conda-forge
-  - omnia
   - defaults
-  - openeye
-  - omnia/label/rc
-  - omnia/label/benchmark
 
 dependencies:
   - python =3.7
   - pip
   - qcportal
-  - openff-qcsubmit =0.2.1
-  - pip:
-#      - basis_set_exchange
-      - PyGithub
-      - pandas
-      - tabulate
+  - openff-qcsubmit =0.2.2
+  - PyGithub
+  - pandas
+  - tabulate

--- a/devtools/conda-envs/validation.yaml
+++ b/devtools/conda-envs/validation.yaml
@@ -2,19 +2,13 @@ name: validation
 
 channels:
   - conda-forge
-  - omnia
   - defaults
-  - openeye
-  - omnia/label/rc
-  - omnia/label/benchmark
 
 dependencies:
   - python =3.7
   - pip
 
-  - openff-qcsubmit =0.2.1
+  - openff-qcsubmit =0.2.2
   - PyGithub
   - pandas
   - tabulate
-#  - pip:
-#      - basis_set_exchange

--- a/management/lifecycle.py
+++ b/management/lifecycle.py
@@ -297,7 +297,7 @@ class SubmittableBase:
         spec = self._load_submittable()
 
         dataset_name = spec["dataset_name"]
-        dataset_type = spec["dataset_type"]
+        dataset_type = spec["type"]
 
         dataset_specs = spec.get("qc_specifications", None)
 
@@ -398,7 +398,7 @@ class SubmittableBase:
                            set_priority=False,
                            set_computetag=False):
         """Obtain complete, incomplete, error stats for submittable and report.
-        
+
         For suspected random errors, we perform restarts.
 
         If submittable complete, recommend state "Archived/Complete".
@@ -818,7 +818,7 @@ class DataSet(SubmittableBase):
 
     """
     def submit(self, dataset_qcs, client):
-        return dataset_qcs.submit(client=client, threads=1)
+        return dataset_qcs.submit(client=client, processes=1)
 
 
 class Compute(SubmittableBase):
@@ -826,7 +826,7 @@ class Compute(SubmittableBase):
 
     """
     def submit(self, dataset_qcs, client):
-        return dataset_qcs.submit(client=client, ignore_errors=True, threads=1)
+        return dataset_qcs.submit(client=client, ignore_errors=True, processes=1)
 
 
 def create_dataset(dataset_data):
@@ -838,7 +838,7 @@ def create_dataset(dataset_data):
         "torsiondrivedataset": TorsiondriveDataset,
     }
 
-    dataset_type = dataset_data["dataset_type"].lower()
+    dataset_type = dataset_data["type"].lower()
     dataset_class = datasets.get(dataset_type, None)
     if dataset_class is not None:
         return dataset_class.parse_obj(dataset_data)
@@ -870,7 +870,7 @@ def get_version_info():
 
     report = {}
     # list the core packages here
-    packages = ["openff.qcsubmit", "openforcefield", "basis_set_exchange", "qcelemental"]
+    packages = ["openff.qcsubmit", "openff.toolkit", "basis_set_exchange", "qcelemental"]
     for package in packages:
         module = importlib.import_module(package)
         report[package] = pd.Series({"version": module.__version__})


### PR DESCRIPTION
## Description

This PR updates the management utilities to use the latest version of QCSubmit (now on C-F). In particular: 

* The latest version introduced a number of API changes (mainly `dataset_type` was renamed to  just `type`) which are resolved here.
* The full stack is now on C-F so the omnia channel is now dropped.
* All references to `openforcefield` are now replaced with `openff.toolkit`.

Closes #212