### PR TITLE
Update to new psi4 rc3 for Iodine issue

### DIFF
--- a/devtools/prod-envs/qcarchive-worker-openff-psi4.yaml
+++ b/devtools/prod-envs/qcarchive-worker-openff-psi4.yaml
@@ -1,15 +1,14 @@
 name: qcarchive-worker-openff-psi4
 channels:
-  - conda-forge
   - psi4/label/dev
   - defaults
 dependencies:
-  - python =3.7
-  - qcfractal =0.15.2
-  - qcengine =0.17.0
+  - python =3.9
+  - qcfractal =0.15.6
+  - qcengine =0.19.0
 
   # QM calculations
-  - psi4 =1.4a3.dev63+afa0c21
+  - psi4 =1.4rc3.dev45+6e00bd3
   - dftd3 =3.2.1
   - gcp
   - gau2grid =2.0.7


### PR DESCRIPTION
Solves iodine issue raised by Bill Swope, which was about a wrong choice of df auxiliary basis. With this environment, when DZVP basis is chosen the auxiliary density fitting basis will be `dgauss-dzvp-mix.gbs`. This new mixed basis matches the previous `def2-qzvpp-jkfit.gbs` from `H - Br`, and for `Kr and beyond` autoaux basis generated by Susi Lehtola for dgauss-dzvp. The choice of `dgauss-dzvp-mix.gbs` is default now if we choose to run calculations with `dzvp`, so there is no need to explicitly add the keyword `df_basis_scf` to our default compute specification in qcsubmit workflow.

One caveat here is the conda channel selection, I encountered `undefined symbol: __svml_exp4_mask_e9` error if I use `conda-forge`, instead of `defaults`, due to some static library issue discussed [here on psi4 slack](https://psi4.slack.com/archives/CHZ65P1R9/p1616798620012900). I don't know the work around for that, other than using the `defaults` channel, which worked smoothly for me. That might be a blocker to use this directly, rest all libraries are pinned to their latest versions as required by psi4.


