### PR TITLE
Update prod envs to use openff-forcefields 2.0.0

### DIFF
--- a/devtools/prod-envs/qcarchive-worker-openff-openmm.yaml
+++ b/devtools/prod-envs/qcarchive-worker-openff-openmm.yaml
@@ -2,7 +2,6 @@ name: qcarchive-worker-openff-openmm
 channels:
   - conda-forge
   - defaults
-  - conda-forge/label/openff-forcefields_dev
 dependencies:
   - python =3.7
   - qcfractal =0.15.2
@@ -10,7 +9,7 @@ dependencies:
     
   # MM calculations
   - openff-toolkit =0.10.0
-  - openff-forcefields =2.0.0rc.2
+  - openff-forcefields =2.0.0
   - openmm =7.5.1
   - openmmforcefields =0.9.0
   - conda-forge::libiconv

--- a/devtools/prod-envs/qcarchive-worker-openff.yaml
+++ b/devtools/prod-envs/qcarchive-worker-openff.yaml
@@ -4,7 +4,6 @@ channels:
   - conda-forge
   - pytorch
   - defaults
-  - conda-forge/label/openff-forcefields_dev
 dependencies:
   - python =3.7
   - pip
@@ -20,7 +19,7 @@ dependencies:
     
   # MM calculations
   - openff-toolkit =0.10.0
-  - openff-forcefields =2.0.0rc.2
+  - openff-forcefields =2.0.0
   - openmm =7.5.1
   - openmmforcefields =0.9.0
   - conda-forge::libiconv


### PR DESCRIPTION
`openff-forcefields` 2.0.0 was released this week. This PR adds production env support for use of Sage in MM computations.