### PR TITLE
Dataset submission errors 

### DIFF
--- a/management/lifecycle.py
+++ b/management/lifecycle.py
@@ -833,7 +833,7 @@ class DataSet(SubmittableBase):
 
     """
     def submit(self, dataset_qcs, client):
-        return dataset_qcs.submit(client=client, processes=1)
+        return dataset_qcs.submit(client=client, processes=1, ignore_errors=True)
 
 
 class Compute(SubmittableBase):


### PR DESCRIPTION
This PR will sync up submissions and compute expansions to allow errors assuming they to be expected during computing. This is useful for adding specs containing ani to datasets with missing element coverage. 