### PR TITLE
Theory benchmark - ANI-2x, GFN2-XTB, heavy-aug-cc-pV(T+d)Z compute specs

### DIFF
--- a/submissions/2021-09-06-theory-bm-single-points/compute.json
+++ b/submissions/2021-09-06-theory-bm-single-points/compute.json
@@ -17,12 +17,46 @@
       ],
       "keywords": null
     },
+    "gfn1xtb": {
+      "method": "gfn1xtb",
+      "basis": null,
+      "program": "xtb",
+      "spec_name": "gfn1xtb",
+      "spec_description": "A default spec for gfn1xtb",
+      "store_wavefunction": "none",
+      "implicit_solvent": null,
+      "maxiter": 200,
+      "scf_properties": [
+        "dipole",
+        "quadrupole",
+        "wiberg_lowdin_indices",
+        "mayer_indices"
+      ],
+      "keywords": null
+    },
     "gfn2xtb": {
       "method": "gfn2xtb",
       "basis": null,
       "program": "xtb",
       "spec_name": "gfn2xtb",
       "spec_description": "A default spec for gfn2xtb",
+      "store_wavefunction": "none",
+      "implicit_solvent": null,
+      "maxiter": 200,
+      "scf_properties": [
+        "dipole",
+        "quadrupole",
+        "wiberg_lowdin_indices",
+        "mayer_indices"
+      ],
+      "keywords": null
+    },
+    "gfnff": {
+      "method": "gfnff",
+      "basis": null,
+      "program": "xtb",
+      "spec_name": "gfnff",
+      "spec_description": "A default spec for gfnff",
       "store_wavefunction": "none",
       "implicit_solvent": null,
       "maxiter": 200,


### PR DESCRIPTION
## Compute Expansion Checklist

- [x] Compute expansion filename matches pattern `compute*.json`; may feature a compression extension, such as `.bz2`
- [ ] QCSubmit validation passed
- [ ] Ready to submit!
