### PR TITLE
Attempt to perform Docker build with mamba to avoid memory issues from conda

### DIFF
--- a/devtools/docker/qcarchive-worker-openff/Dockerfile
+++ b/devtools/docker/qcarchive-worker-openff/Dockerfile
@@ -1,9 +1,9 @@
-FROM continuumio/miniconda3
+FROM condaforge/mambaforge
 
 SHELL ["/bin/bash", "-c"]
 
-RUN conda install anaconda-client
-RUN conda env create -n qcfractal openforcefield/${ENV_NAME}
+RUN mamba install anaconda-client
+RUN mamba env create -n qcfractal openforcefield/${ENV_NAME}
 
 RUN groupadd -g 999 qcfractal && \
     useradd -m -r -u 999 -g qcfractal qcfractal


### PR DESCRIPTION
<!-- Choose the checklist below based on the type of PR this is -->
<!-- Delete all other checklists -->

See title; hitting what appear to be memory issues in build for openff docker image.
Switching to mamba to address this.
