### PR TITLE
Add unused arguments to execute_requires_scientific_review

### DIFF
--- a/management/lifecycle.py
+++ b/management/lifecycle.py
@@ -267,7 +267,7 @@ class Submission:
                 ds = DataSet(dataset, self, self.ghapi)
                 ds.comment_archived_complete()
 
-    def execute_requires_scientific_review(self):
+    def execute_requires_scientific_review(self, pr_card, pr_state):
         # add `scientific-review` label
         # remove `end-of-life`, `complete` label if present
         labels =  set(map(lambda x: x.name, self.pr.labels))


### PR DESCRIPTION
<!-- Choose the checklist below based on the type of PR this is -->
<!-- Delete all other checklists -->

Fixes #358 by adding two unused arguments to the function, in line with the other execute_state functions.