### PR TITLE
Update automation environments

### DIFF
--- a/devtools/conda-envs/error-cycle.yaml
+++ b/devtools/conda-envs/error-cycle.yaml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - python
   - qcportal >=0.49
-  - openff-qcsubmit >=0.50.1
+  - openff-qcsubmit >=0.53.0
   - openff-toolkit-base >=0.12
   - openff-forcefields >=2.0.0
   - PyGithub

--- a/devtools/conda-envs/queued-submit.yaml
+++ b/devtools/conda-envs/queued-submit.yaml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - python
   - qcportal >=0.49
-  - openff-qcsubmit >=0.50.1
+  - openff-qcsubmit >=0.53.0
   - openff-toolkit-base >=0.12
   - openff-forcefields >=2.0.0
   - PyGithub

--- a/devtools/conda-envs/validation.yaml
+++ b/devtools/conda-envs/validation.yaml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - python
   - qcportal >=0.49
-  - openff-qcsubmit >=0.50.1
+  - openff-qcsubmit >=0.53.0
   - openff-toolkit-base >=0.12
   - openff-forcefields >=2.0.0
   - basis_set_exchange


### PR DESCRIPTION
Update the automation environments to use the latest qcsubmit versions which should allow the MLPepper dataset to submit, see failed attempt [here](https://github.com/openforcefield/qca-dataset-submission/actions/runs/10380312200/job/28739926732). 