### PR TITLE
fix ddx env

### DIFF
--- a/devtools/prod-envs/qcarchive-worker-openff-psi4-ddx.yaml
+++ b/devtools/prod-envs/qcarchive-worker-openff-psi4-ddx.yaml
@@ -8,14 +8,15 @@ dependencies:
   - qcfractalcompute
   - qcengine
   - qcelemental
-
+  
   # QM calculations
   - psi4
   - pyddx 
   - dftd3-python
   - gcp-correction
   - scipy
-    
+  - openff-toolkit
+
   # procedures
   - geometric
 

--- a/devtools/prod-envs/qcarchive-worker-openff-psi4.yaml
+++ b/devtools/prod-envs/qcarchive-worker-openff-psi4.yaml
@@ -14,6 +14,7 @@ dependencies:
   - dftd3-python
   - gcp-correction
   - scipy
+  - openff-toolkit
     
   # procedures
   - geometric


### PR DESCRIPTION
Previously running with the psi4 ddx env, all molecules failed validation qcengine: 
`ValidationError: Following atoms are too close
`. This was encountered while spinning up the workers for this submission https://github.com/openforcefield/qca-dataset-submission/tree/master/submissions/2024-10-11-MLPepper-RECAP-Optimized-Fragments-Add-Iodines-v1.0. 

Adding openff-toolkit fixed the issue, but specifically this seemed to downgrade qcfractal-compute and qcportal from 0.56 to 0.54.1

