### PR TITLE
Split dataset tags based on PR labels

### DIFF
--- a/management/lifecycle.py
+++ b/management/lifecycle.py
@@ -134,6 +134,16 @@ def set_mw_compute_tags(client, ds, compute_tag, include_complete=False):
         client.modify_records(record_ids, new_tag=new_tag)
 
 
+def update_compute_tags(client, dataset, specification_names, new_tag, include_complete=False):
+    if SPLIT_TAG.search(new_tag) is None:
+        dataset.modify_records(
+            specification_names=specification_names,
+            new_tag=new_tag,
+        )
+    else:
+        set_mw_compute_tags(client, dataset, new_tag, include_complete=include_complete)
+
+
 class Submission:
     """A submission, corresponding to a single PR, possibly multiple datasets.
 
@@ -713,11 +723,12 @@ class SubmittableBase:
                 ds.modify_records(specification_names=list(dataset_specs),
                                   new_priority=self.priority)
             if set_computetag:
-                if SPLIT_TAG.search(self.computetag) is None:
-                    ds.modify_records(specification_names=list(dataset_specs),
-                                    new_tag=self.computetag)
-                else:
-                    set_mw_compute_tags(client, ds, self.computetag)
+                update_compute_tags(
+                    client=client,
+                    dataset=ds,
+                    specification_names=list(dataset_specs),
+                    new_tag=self.computetag,
+                )
 
             complete = False
 
@@ -852,11 +863,12 @@ class SubmittableBase:
                 ds.modify_records(specification_names=list(dataset_specs),
                                   new_priority=self.priority)
             if set_computetag:
-                if SPLIT_TAG.search(self.computetag) is None:
-                    ds.modify_records(specification_names=list(dataset_specs),
-                                    new_tag=self.computetag)
-                else:
-                    set_mw_compute_tags(client, ds, self.computetag)
+                update_compute_tags(
+                    client=client,
+                    dataset=ds,
+                    specification_names=list(dataset_specs),
+                    new_tag=self.computetag,
+                )
             complete = False
 
         return complete

--- a/management/lifecycle.py
+++ b/management/lifecycle.py
@@ -127,6 +127,24 @@ def set_mw_compute_tags(client, ds, compute_tag, include_complete=False):
 
 
 def update_compute_tags(client, dataset, specification_names, new_tag, include_complete=False):
+    """Update the compute tags in ``dataset`` to ``new_tag``, unless the new
+    tag matches the ``SPLIT_TAG`` pattern, in which case the dataset will be
+    split up and tagged separately based on molecular weight. For example,
+    ``compute-openff_mw-100-200-300`` will cause the creation of four tags:
+    ``compute-openff-100`` for MW < 100, ``compute-openff-200`` for 100 <= MW <
+    200, ``compute-openff-300`` for 200 <= MW < 300, and
+    ``compute-openff-large`` for anything larger than 300 Da.
+
+    Note that ``set_mw_compute_tags`` does not need access to the specification
+    names because it calls ``PortalClient.modify_records``, which, despite the
+    identical name, is a separate method from ``BaseDataset.modify_records``.
+    The client version used by ``set_mw_compute_tags`` relies on the record IDs
+    to specify records instead of the specification name.
+
+    Note also that ``set_mw_compute_tags`` should only be called when
+    ``SPLIT_TAG`` matches the tag. It will print a warning and return early,
+    updating no tags, if this is not the case.
+    """
     if SPLIT_TAG.search(new_tag) is None:
         dataset.modify_records(
             specification_names=specification_names,

--- a/management/test_lifecycle.py
+++ b/management/test_lifecycle.py
@@ -1,0 +1,104 @@
+import sys
+from unittest import mock
+
+import pytest
+
+# avoid requiring PyGitHub to run tests
+sys.modules["github"] = mock.MagicMock()
+
+
+@pytest.mark.parametrize(
+    "input_tag,want",
+    [
+        ("compute-openff_mw-300-600", ([300.0, 600.0], "compute-openff")),
+        (
+            "compute-pr393_mw-300-600-900",
+            ([300.0, 600.0, 900.0], "compute-pr393"),
+        ),
+        ("compute-pr393", ([], "compute-pr393")),
+    ],
+)
+def test_parse_tags(input_tag, want):
+    from lifecycle import parse_tags
+
+    got = parse_tags(input_tag)
+    assert got == want
+
+
+@pytest.mark.parametrize(
+    "dsname,dstype,bins,want",
+    [
+        (
+            "OpenFF Sulfur Hessian Training Coverage Supplement v1.0",
+            "singlepoint",
+            [100.0, 200.0, 300.0],
+            [6, 220, 240, 433],
+        ),
+        (
+            "OpenFF Sulfur Optimization Training Coverage Supplement v1.0",
+            "Optimization",
+            [100.0, 200.0, 300.0],
+            [6, 220, 240, 433],
+        ),
+        (
+            "OpenFF Alkane Torsion Drives v1.0",
+            "torsiondrive",
+            [50.0, 75.0, 100.0],
+            [2, 30, 68, 92],
+        ),
+    ],
+)
+def test_partition_records(dsname, dstype, bins, want):
+    from qcportal import PortalClient
+
+    from lifecycle import partition_records
+
+    client = PortalClient("https://api.qcarchive.molssi.org:443/")
+
+    ds = client.get_dataset(dstype, dsname)
+
+    records = partition_records(ds, bins, include_complete=True)
+
+    lens = [len(v) for v in records.values()]
+    assert sum(lens) == len(list(ds.iterate_entries()))
+
+    assert list(sorted(lens)) == want
+
+
+@pytest.mark.parametrize(
+    "dsname,dstype,tag,want",
+    [
+        (
+            "OpenFF Sulfur Hessian Training Coverage Supplement v1.0",
+            "singlepoint",
+            "compute-openff_mw-100-200-300",
+            [
+                (6, "compute-openff-100"),
+                (220, "compute-openff-large"),
+                (240, "compute-openff-300"),
+                (433, "compute-openff-200"),
+            ],
+        ),
+    ],
+)
+def test_set_mw_compute_tags(dsname, dstype, tag, want):
+    from qcportal import PortalClient
+
+    from lifecycle import set_mw_compute_tags
+
+    class DummyClient:
+        def __init__(self):
+            self.calls = list()
+
+        def modify_records(self, record_ids, new_tag):
+            self.calls.append((len(record_ids), new_tag))
+
+    client = PortalClient("https://api.qcarchive.molssi.org:443/")
+    ds = client.get_dataset(dstype, dsname)
+
+    dummy = DummyClient()
+    set_mw_compute_tags(dummy, ds, tag, include_complete=True)
+
+    # calls depends on dict iteration order, so sort the output by number of
+    # record_ids in each bin
+    assert list(sorted(dummy.calls, key=lambda x: x[0])) == want

--- a/management/test_lifecycle.py
+++ b/management/test_lifecycle.py
@@ -32,13 +32,13 @@ def test_parse_tags(input_tag, want):
             "OpenFF Sulfur Hessian Training Coverage Supplement v1.0",
             "singlepoint",
             [100.0, 200.0, 300.0],
-            [6, 220, 240, 433],
+            [6, 220, 234, 439],
         ),
         (
             "OpenFF Sulfur Optimization Training Coverage Supplement v1.0",
             "Optimization",
             [100.0, 200.0, 300.0],
-            [6, 220, 240, 433],
+            [6, 220, 234, 439],
         ),
         (
             "OpenFF Alkane Torsion Drives v1.0",
@@ -75,8 +75,8 @@ def test_partition_records(dsname, dstype, bins, want):
             [
                 (6, "compute-openff-100"),
                 (220, "compute-openff-large"),
-                (240, "compute-openff-300"),
-                (433, "compute-openff-200"),
+                (234, "compute-openff-300"),
+                (439, "compute-openff-200"),
             ],
         ),
     ],

--- a/management/test_lifecycle.py
+++ b/management/test_lifecycle.py
@@ -35,19 +35,19 @@ def test_parse_tags(input_tag, want):
             "OpenFF Sulfur Hessian Training Coverage Supplement v1.0",
             "singlepoint",
             [100.0, 200.0, 300.0],
-            [6, 220, 234, 439],
+            {0: 6, 1: 439, 2: 234, 3: 220},
         ),
         (
             "OpenFF Sulfur Optimization Training Coverage Supplement v1.0",
             "Optimization",
             [100.0, 200.0, 300.0],
-            [6, 220, 234, 439],
+            {0: 6, 1: 439, 2: 234, 3: 220},
         ),
         (
             "OpenFF Alkane Torsion Drives v1.0",
             "torsiondrive",
             [50.0, 75.0, 100.0],
-            [2, 30, 68, 92],
+            {0: 2, 1: 30, 2: 92, 3: 68},
         ),
     ],
 )
@@ -65,7 +65,8 @@ def test_partition_records(dsname, dstype, bins, want):
     lens = [len(v) for v in records.values()]
     assert sum(lens) == len(list(ds.iterate_entries()))
 
-    assert list(sorted(lens)) == want
+    got = {bin_id: len(recs) for bin_id, recs in records.items()}
+    assert got == want
 
 
 @pytest.mark.parametrize(

--- a/management/test_lifecycle.py
+++ b/management/test_lifecycle.py
@@ -16,12 +16,18 @@ sys.modules["github"] = mock.MagicMock()
             ([300.0, 600.0, 900.0], "compute-arbitrary-compute-tag"),
         ),
         (
-            "compute-arbitrary-compute-tag",
-            ([], "compute-arbitrary-compute-tag"),
+            "compute-arbitrary-compute-tag-without-mw-suffix",
+            ([], "compute-arbitrary-compute-tag-without-mw-suffix"),
         ),
     ],
 )
 def test_parse_tags(input_tag, want):
+    """Test that ``parse_tags`` parses arbitrary compute tags ending with
+    ``_mw[-###]+`` (matching the ``lifecycle.SPLIT_TAG`` regex). This function
+    is not intended to be called with non-matching tags (as in the third test
+    entry), but it should also handle this gracefully, returning an empty
+    sequence of bins and the original tag.
+    """
     from lifecycle import parse_tags
 
     got = parse_tags(input_tag)

--- a/management/test_lifecycle.py
+++ b/management/test_lifecycle.py
@@ -81,10 +81,10 @@ def test_partition_records(dsname, dstype, bins, want):
         ),
     ],
 )
-def test_set_mw_compute_tags(dsname, dstype, tag, want):
+def test_update_compute_tags(dsname, dstype, tag, want):
     from qcportal import PortalClient
 
-    from lifecycle import set_mw_compute_tags
+    from lifecycle import update_compute_tags
 
     class DummyClient:
         def __init__(self):
@@ -97,7 +97,7 @@ def test_set_mw_compute_tags(dsname, dstype, tag, want):
     ds = client.get_dataset(dstype, dsname)
 
     dummy = DummyClient()
-    set_mw_compute_tags(dummy, ds, tag, include_complete=True)
+    update_compute_tags(dummy, ds, list(), tag, include_complete=True)
 
     # calls depends on dict iteration order, so sort the output by number of
     # record_ids in each bin

--- a/management/test_lifecycle.py
+++ b/management/test_lifecycle.py
@@ -12,10 +12,13 @@ sys.modules["github"] = mock.MagicMock()
     [
         ("compute-openff_mw-300-600", ([300.0, 600.0], "compute-openff")),
         (
-            "compute-pr393_mw-300-600-900",
-            ([300.0, 600.0, 900.0], "compute-pr393"),
+            "compute-arbitrary-compute-tag_mw-300-600-900",
+            ([300.0, 600.0, 900.0], "compute-arbitrary-compute-tag"),
         ),
-        ("compute-pr393", ([], "compute-pr393")),
+        (
+            "compute-arbitrary-compute-tag",
+            ([], "compute-arbitrary-compute-tag"),
+        ),
     ],
 )
 def test_parse_tags(input_tag, want):


### PR DESCRIPTION
This implements the feature discussed in #408, where labels beginning with `compute-` (this is enforced by the original code) and ending with `_mw-300-600-900`, just for example, the numbers can be anything, will be split up and tag separate portions of the dataset based on molecular weight. For example, `compute-openff_mw-100-200-300` will cause the creation of four tags: `compute-openff-100` for MW < 100, `compute-openff-200` for 100 <= MW < 200, `compute-openff-300` for 200 <= MW < 300, and `compute-openff-large` for anything larger than 300 Da. I wrote the splitting code in a generic way, so it should also handle  different numbers of groups other than 3, for example `_mw-300` or `_mw-100-200-300-400-500`.

For tags that don't match the pattern, the usual behavior should be preserved, which is good because the splitting implementation I added has to retrieve the dataset and iterate over its records to compute molecular weights, making it more expensive than the plain `dataset.modify_records` call.

I added a file `test_lifecycle.py` to test my implementation. I don't think this is run as part of normal CI, but it's at least helpful for local development.