### PR TITLE
Updating validation environment to update units package

### DIFF
--- a/devtools/conda-envs/error-cycle.yaml
+++ b/devtools/conda-envs/error-cycle.yaml
@@ -6,9 +6,10 @@ channels:
 dependencies:
   - python
   - qcportal >=0.49
-  - openff-qcsubmit >=0.53.0
+  - openff-qcsubmit >=0.55.0
   - openff-toolkit-base >=0.12
   - openff-forcefields >=2.0.0
+  - openff-units >= 0.2.0
   - PyGithub
   - pandas
   - tabulate

--- a/devtools/conda-envs/queued-submit.yaml
+++ b/devtools/conda-envs/queued-submit.yaml
@@ -6,9 +6,10 @@ channels:
 dependencies:
   - python
   - qcportal >=0.49
-  - openff-qcsubmit >=0.53.0
+  - openff-qcsubmit >=0.55.0
   - openff-toolkit-base >=0.12
   - openff-forcefields >=2.0.0
+  - openff-units >= 0.2.0
   - PyGithub
   - pandas
   - tabulate

--- a/devtools/conda-envs/validation.yaml
+++ b/devtools/conda-envs/validation.yaml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - python
   - qcportal >=0.49
-  - openff-qcsubmit >=0.53.0
+  - openff-qcsubmit >=0.55.0
   - openff-toolkit-base >=0.12
   - openff-forcefields >=2.0.0
   - openff-units >= 0.2.0

--- a/devtools/conda-envs/validation.yaml
+++ b/devtools/conda-envs/validation.yaml
@@ -9,6 +9,7 @@ dependencies:
   - openff-qcsubmit >=0.53.0
   - openff-toolkit-base >=0.12
   - openff-forcefields >=2.0.0
+  - openff-units >= 0.2.0
   - basis_set_exchange
   - pydantic
   - typing-extensions


### PR DESCRIPTION
Pinned the version of `openff-units` in the validation environment to avoid import error described in #429 . Fixes #429 for me locally, but I can't run the full validation locally due to missing a github token.