### PR TITLE
Update README.md

### DIFF
--- a/submissions/2021-12-21-OpenFF-Gen2-Optimization-Set-Protomers/README.md
+++ b/submissions/2021-12-21-OpenFF-Gen2-Optimization-Set-Protomers/README.md
@@ -13,7 +13,7 @@ Molecules with nitro groups are excluded from this filtering since pentavalent n
  - Name: OpenFF Gen2 Optimization Dataset Protomers v1.0
  - Number of unique molecules        110
  - Number of filtered molecules      0
- - Number of conformers              600
+ - Number of conformers              600   (note: this number reflects the data on QCArchive. 610 records were originally submitted, but only 600 were added to QCArchive at time of submission; hence there is a mismatch between the number of records in the `dataset.json.bz2` here, 610, and the actual dataset on QCArchive, 600). 
  - Number of conformers min mean max 1   5.45 10
  - Mean molecular weight: 338.5
  - Max molecular weight: 542.16


### PR DESCRIPTION
The README for `OpenFF Gen2 Optimization Dataset Protomers v1.0` is not accurate for the contents of the dataset *at the time of submission*. Currently, the README says there are 610 conformers, while the dataset shows 600 records. In the [original PR](https://github.com/openforcefield/qca-dataset-submission/pull/263) that submitted this dataset, the error cycling reports also show 600 records, showing that the number of conformers in the README was inaccurate at the time of submission.

This PR updates the README data for this dataset with the following code:
```python
from collections import defaultdict
import numpy as np
from qcportal import PortalClient

qc_client = PortalClient("https://api.qcarchive.molssi.org:443/", cache_dir=".")
ds = qc_client.get_dataset("optimization", "OpenFF Gen2 Optimization Dataset Protomers v1.0")
entries = [*ds.iterate_entries()]

counter = defaultdict(lambda: 0)
mw_array = []
charges = []
for entry in entries:
    counter[entry.attributes["canonical_smiles"]] += 1
    mw_array.append(sum(entry.initial_molecule.masses))
    charges.append(entry.initial_molecule.molecular_charge)

print("Molecules", len(counter), "Conformers", sum(counter.values()))
print("Number of Conformers (min, mean, max)", min(counter.values()), np.mean(list(counter.values())), max(counter.values()))
print("MW Min, Mean, Max", np.min(mw_array), np.mean(mw_array), max(mw_array))
print("Charges", sorted(set(charges)))
```