### PR TITLE
Add notebooks for each dataset type

### DIFF
--- a/archival/Dockerfile
+++ b/archival/Dockerfile
@@ -3,7 +3,7 @@ FROM condaforge/miniforge3
 SHELL ["/bin/bash", "-c"]
 
 ADD environment.yaml /tmp/env.yaml
-ADD dataset_handling.ipynb /workspace/dataset_handling.ipynb
+ADD dataset_handling_v1.0.ipynb /workspace/dataset_handling_v1.0.ipynb
 
 RUN mamba env create -n qca -f /tmp/env.yaml && \
     mamba shell init --shell bash && \
@@ -19,4 +19,4 @@ ENV PATH=/opt/conda/envs/qca/bin:$PATH
 EXPOSE 8888
 
 # Start Jupyter Lab with the notebook
-CMD ["jupyter", "lab", "dataset_handling.ipynb", "--ip=0.0.0.0", "--no-browser", "--allow-root"]
+CMD ["jupyter", "lab", "dataset_handling_v1.0.ipynb", "--ip=0.0.0.0", "--no-browser", "--allow-root"]

--- a/archival/dataset_handling_optimization_v1.0.ipynb
+++ b/archival/dataset_handling_optimization_v1.0.ipynb
@@ -1,0 +1,176 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e231b674",
+   "metadata": {},
+   "source": [
+    "# Basic Handling of QCFractal Dataset Views for Force Field Fitting\n",
+    "\n",
+    "In this notebook we show examples of how the views can be interacted with. Using the provided docker image, feel free to browse the data.\n",
+    "\n",
+    "## Import packages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "abb55e70",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import glob\n",
+    "from pprint import pprint\n",
+    "\n",
+    "import numpy as np\n",
+    "from qcportal import load_dataset_view\n",
+    "from qcportal.serialization import encode_to_json\n",
+    "from openff.units import unit\n",
+    "from openff.toolkit import Molecule\n",
+    "from forcebalance.molecule import Molecule as FBMolecule"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8a43ad83",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filename_opt_dsv = \"views/OpenFF-SMIRNOFF-Sage-2.2.0_optimization_view.sqlite\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bef9ecba",
+   "metadata": {},
+   "source": [
+    "## Optimization Dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "40efd1fc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dsv_opt = load_dataset_view(filename_opt_dsv)\n",
+    "\n",
+    "all_records = list(dsv_opt.iterate_records())\n",
+    "all_entries = list(dsv_opt.iterate_entries())\n",
+    "\n",
+    "# Map entry names to records and entries\n",
+    "name_to_records = {\n",
+    "    name: record\n",
+    "    for name, _, record in all_records\n",
+    "}\n",
+    "name_to_entry = {\n",
+    "    entry.name: entry\n",
+    "    for entry in all_entries\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0665f006",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for name, record in name_to_records.items():\n",
+    "    try:\n",
+    "        mapped_smiles = name_to_entry[name].attributes[\"canonical_isomeric_explicit_hydrogen_mapped_smiles\"]\n",
+    "    except KeyError:\n",
+    "        try:\n",
+    "            mapped_smiles = name_to_entry[name].initial_molecule.extras[\"canonical_isomeric_explicit_hydrogen_mapped_smiles\"]\n",
+    "        except KeyError:\n",
+    "            raise KeyError(\"canonical_isomeric_explicit_hydrogen_mapped_smiles\")\n",
+    "    geometry_au = record.final_molecule.geometry\n",
+    "\n",
+    "    molecule = Molecule.from_mapped_smiles(mapped_smiles, allow_undefined_stereo=True)\n",
+    "    molecule.add_conformer(\n",
+    "        np.array(geometry_au) * unit.bohr\n",
+    "    )\n",
+    "    # Files used in ForceBalance -- name uniquely for different targets\n",
+    "    molecule.to_file(\"outputs/mol.pdb\", \"PDB\")\n",
+    "    molecule.to_file(\"outputs/mol.xyz\", \"XYZ\")\n",
+    "    molecule.to_file(\"outputs/mol.sdf\", \"SDF\")\n",
+    "\n",
+    "    # Alternatively, using QCElemental\n",
+    "    xyz_str = record.final_molecule.to_string(\"xyz\")\n",
+    "    open(\"outputs/qce_mol.xyz\", \"w\").write(xyz_str)\n",
+    "\n",
+    "    # Alternatively, using ForceBalance\n",
+    "    fb_molecule = FBMolecule()\n",
+    "    fb_molecule.Data = {\n",
+    "        \"resname\": [\"UNK\"] * molecule.n_atoms,\n",
+    "        \"resid\": [0] * molecule.n_atoms,\n",
+    "        \"elem\": [atom.symbol for atom in molecule.atoms],\n",
+    "        \"bonds\": [\n",
+    "            (bond.atom1_index, bond.atom2_index) for bond in molecule.bonds\n",
+    "        ],\n",
+    "        \"name\": f\"{record.id}\",\n",
+    "        \"xyzs\": [molecule.conformers[0].m_as(unit.angstrom)],\n",
+    "    }\n",
+    "    fb_molecule.write(\"outputs/mol.pdb\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c9aeed22",
+   "metadata": {},
+   "source": [
+    "## Pulling Energies / Geometries from Dataset View"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dcc7154a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "entry_name = list(name_to_records.keys())[0]\n",
+    "record = name_to_records[entry_name]\n",
+    "\n",
+    "print(f\"The final energy of this record is: {record.energies[-1]}\")\n",
+    "print(f\"The final geometry of this record is:\\n{record.final_molecule.geometry}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c0777a4c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create dictionary of output\n",
+    "rec_dict = encode_to_json(record)\n",
+    "pprint(rec_dict)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/archival/dataset_handling_singlepoint_v1.0.ipynb
+++ b/archival/dataset_handling_singlepoint_v1.0.ipynb
@@ -1,0 +1,177 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e231b674",
+   "metadata": {},
+   "source": [
+    "# Basic Handling of QCFractal Dataset Views for Force Field Fitting\n",
+    "\n",
+    "In this notebook we show examples of how the views can be interacted with. Using the provided docker image, feel free to browse the data.\n",
+    "\n",
+    "## Import packages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "abb55e70",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import glob\n",
+    "from pprint import pprint\n",
+    "\n",
+    "import numpy as np\n",
+    "from qcportal import load_dataset_view\n",
+    "from qcportal.serialization import encode_to_json\n",
+    "from openff.units import unit\n",
+    "from openff.toolkit import Molecule\n",
+    "from forcebalance.molecule import Molecule as FBMolecule"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8a43ad83",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filename_sp_dsv = \"views/OpenFF-ESP-Fragment-Conformers-v1.0_singlepoint_view.sqlite\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bef9ecba",
+   "metadata": {},
+   "source": [
+    "## Optimization Dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "40efd1fc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dsv_sp = load_dataset_view(filename_sp_dsv)\n",
+    "\n",
+    "all_records = list(dsv_sp.iterate_records())\n",
+    "all_entries = list(dsv_sp.iterate_entries())\n",
+    "\n",
+    "# Map entry names to records and entries\n",
+    "name_to_records = {\n",
+    "    name: record\n",
+    "    for name, _, record in all_records\n",
+    "}\n",
+    "name_to_entry = {\n",
+    "    entry.name: entry\n",
+    "    for entry in all_entries\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0665f006",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for name, record in name_to_records.items():\n",
+    "    try:\n",
+    "        mapped_smiles = name_to_entry[name].attributes[\"canonical_isomeric_explicit_hydrogen_mapped_smiles\"]\n",
+    "    except KeyError:\n",
+    "        try:\n",
+    "            mapped_smiles = name_to_entry[name].molecule.extras[\"canonical_isomeric_explicit_hydrogen_mapped_smiles\"]\n",
+    "        except KeyError:\n",
+    "            raise KeyError(\"canonical_isomeric_explicit_hydrogen_mapped_smiles\")\n",
+    "\n",
+    "    geometry_au = record.molecule.geometry\n",
+    "\n",
+    "    molecule = Molecule.from_mapped_smiles(mapped_smiles, allow_undefined_stereo=True)\n",
+    "    molecule.add_conformer(\n",
+    "        np.array(geometry_au) * unit.bohr\n",
+    "    )\n",
+    "    # Files used in ForceBalance -- name uniquely for different targets\n",
+    "    molecule.to_file(\"outputs/mol.pdb\", \"PDB\")\n",
+    "    molecule.to_file(\"outputs/mol.xyz\", \"XYZ\")\n",
+    "    molecule.to_file(\"outputs/mol.sdf\", \"SDF\")\n",
+    "\n",
+    "    # Alternatively, using QCElemental\n",
+    "    xyz_str = record.molecule.to_string(\"xyz\")\n",
+    "    open(\"outputs/qce_mol.xyz\", \"w\").write(xyz_str)\n",
+    "\n",
+    "    # Alternatively, using ForceBalance\n",
+    "    fb_molecule = FBMolecule()\n",
+    "    fb_molecule.Data = {\n",
+    "        \"resname\": [\"UNK\"] * molecule.n_atoms,\n",
+    "        \"resid\": [0] * molecule.n_atoms,\n",
+    "        \"elem\": [atom.symbol for atom in molecule.atoms],\n",
+    "        \"bonds\": [\n",
+    "            (bond.atom1_index, bond.atom2_index) for bond in molecule.bonds\n",
+    "        ],\n",
+    "        \"name\": f\"{record.id}\",\n",
+    "        \"xyzs\": [molecule.conformers[0].m_as(unit.angstrom)],\n",
+    "    }\n",
+    "    fb_molecule.write(\"outputs/mol.pdb\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c9aeed22",
+   "metadata": {},
+   "source": [
+    "## Pulling Energies / Geometries from Dataset View"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dcc7154a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "entry_name = list(name_to_records.keys())[0]\n",
+    "record = name_to_records[entry_name]\n",
+    "\n",
+    "print(f\"The energy of this record is: {record.properties['return_energy']}\")\n",
+    "print(f\"The geometry of this record is:\\n{record.molecule.geometry}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c0777a4c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create dictionary of output\n",
+    "rec_dict = encode_to_json(record)\n",
+    "pprint(rec_dict)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/archival/dataset_handling_torsiondrive_v1.0.ipynb
+++ b/archival/dataset_handling_torsiondrive_v1.0.ipynb
@@ -1,0 +1,207 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e231b674",
+   "metadata": {},
+   "source": [
+    "# Basic Handling of QCFractal Dataset Views for Force Field Fitting\n",
+    "\n",
+    "In this notebook we show examples of how the views can be interacted with. Using the provided docker image, feel free to browse the data.\n",
+    "\n",
+    "## Import packages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "abb55e70",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "from pprint import pprint\n",
+    "\n",
+    "import numpy as np\n",
+    "from qcportal import load_dataset_view\n",
+    "from qcportal.serialization import encode_to_json\n",
+    "from openff.units import unit\n",
+    "from openff.toolkit import Molecule\n",
+    "from forcebalance.molecule import Molecule as FBMolecule"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8a43ad83",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#filename_td_dsv = \"views/OpenFF-SMIRNOFF-Sage-2.2.0_torsiondrive_view.sqlite\"\n",
+    "filename_td_dsv = \"views/OpenFF-Rowley-Biaryl-v1.0_torsiondrive_view.sqlite\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ebaf73b5",
+   "metadata": {},
+   "source": [
+    "## Torsiondrive Dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e34299f8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dsv_td = load_dataset_view(filename_td_dsv)\n",
+    "\n",
+    "all_td_records = list(dsv_td.iterate_records())\n",
+    "all_td_entries = list(dsv_td.iterate_entries())\n",
+    "\n",
+    "# Map entry names to records and entries\n",
+    "td_name_to_records = {\n",
+    "    name: record\n",
+    "    for name, _, record in all_td_records\n",
+    "}\n",
+    "td_name_to_entry = {\n",
+    "    entry.name: entry\n",
+    "    for entry in all_td_entries\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f11cbc9e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for name, record in td_name_to_records.items():\n",
+    "    energies = record.final_energies\n",
+    "    try:\n",
+    "        mapped_smiles = td_name_to_entry[name].attributes[\"canonical_isomeric_explicit_hydrogen_mapped_smiles\"]\n",
+    "    except KeyError:\n",
+    "        try:\n",
+    "            mapped_smiles = td_name_to_entry[name].initial_molecules[0].extras[\"canonical_isomeric_explicit_hydrogen_mapped_smiles\"]\n",
+    "        except KeyError:\n",
+    "            raise KeyError(\"canonical_isomeric_explicit_hydrogen_mapped_smiles\")\n",
+    "    grid_ids = sorted(energies)\n",
+    "    \n",
+    "        \n",
+    "    grid_conformers = []\n",
+    "    molecule = Molecule.from_mapped_smiles(mapped_smiles, allow_undefined_stereo=True)\n",
+    "    for grid_id in grid_ids:\n",
+    "        # The `grid_id`` is a tuple of angles. Usually our TorsionDrives used in FF fits are 1D,\n",
+    "        # so `grid_id`` is expected to be a tuple with a single float (e.g. (0,)).\n",
+    "        energy = energies[grid_id]\n",
+    "        geometry_au = record.minimum_optimizations[grid_id].final_molecule.geometry\n",
+    "        \n",
+    "        molecule.add_conformer(\n",
+    "            np.array(geometry_au) * unit.bohr\n",
+    "        )\n",
+    "        # Save the molecule to file if you want to fit with your own workflow\n",
+    "        # molecule.to_file(...)\n",
+    "        grid_conformers.append(molecule.conformers[0].m_as(unit.angstrom))\n",
+    "\n",
+    "    # Write files used in a TorsionProfileTarget fit in ForceBalance\n",
+    "    fb_molecule = FBMolecule()\n",
+    "    fb_molecule.Data = {\n",
+    "        \"resname\": [\"UNK\"] * molecule.n_atoms,\n",
+    "        \"resid\": [0] * molecule.n_atoms,\n",
+    "        \"elem\": [atom.symbol for atom in molecule.atoms],\n",
+    "        \"bonds\": [\n",
+    "            (bond.atom1_index, bond.atom2_index) for bond in molecule.bonds\n",
+    "        ],\n",
+    "        \"name\": f\"{record.id}\",\n",
+    "        \"xyzs\": grid_conformers,\n",
+    "        # Expect AU energies here\n",
+    "        \"qm_energies\": [energies[grid_id] for grid_id in grid_ids],\n",
+    "        \"comms\": [f\"torsion grid {grid_id}\" for grid_id in grid_ids],\n",
+    "    }\n",
+    "    fb_molecule.write(\"outputs/qdata.txt\")\n",
+    "    fb_molecule.write(\"outputs/scan.xyz\")\n",
+    "\n",
+    "    # Write first conformer\n",
+    "    molecule._conformers = molecule._conformers[:1]\n",
+    "    molecule.to_file(\"outputs/input.sdf\", \"SDF\")\n",
+    "    molecule.to_file(\"outputs/conf.pdb\", \"PDB\")\n",
+    "\n",
+    "    # Write metadata\n",
+    "    metadata = record.specification.optimization_specification.keywords\n",
+    "    # The dihedrals are the 0-indexed atoms that are the rotated dihedral.\n",
+    "    metadata[\"dihedrals\"] = record.specification.keywords.dihedrals\n",
+    "    metadata[\"torsion_grid_ids\"] = grid_ids\n",
+    "    metadata[\"energy_decrease_thresh\"] = None\n",
+    "    metadata[\"energy_upper_limit\"] = 8.0 # cutoff used in Sage 2.2.1\n",
+    "    \n",
+    "    with open(\"outputs/metadata.json\", \"w\") as f:\n",
+    "        json.dump(metadata, f, indent=4)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c9aeed22",
+   "metadata": {},
+   "source": [
+    "## Pulling Energies / Geometries from Dataset View"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dcc7154a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "name_to_records = {\n",
+    "    name: record\n",
+    "    for name, _, record in dsv_td.iterate_records()\n",
+    "}\n",
+    "entry_name = list(name_to_records.keys())[0]\n",
+    "record = name_to_records[entry_name]\n",
+    "\n",
+    "print(f\"The final energy for each gemetry in the scan represented by this record is:\")\n",
+    "for angle, opt_record in record.minimum_optimizations.items():\n",
+    "    print(f\"    {angle}\\t{opt_record.energies[-1]}\")\n",
+    "\n",
+    "print(f\"The final geometry for the first optimization in this record is:\\n{record.minimum_optimizations[(0,)].final_molecule.geometry}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c0777a4c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create dictionary of output\n",
+    "rec_dict = encode_to_json(record)\n",
+    "pprint(rec_dict)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Update the archival materials to include notebooks for single datasets, either torsiondrive, optimization, or singlepoint.

- The optimization notebook is identical to the optimization portion of the original notebook, with the addition of a try/except statement to find the CMILES information.
- The torsiondrive notebook is identical to the optimization portion of the original notebook, with an alteration of the printed energies at the end.
- The singlepoint notebook is based on the optimization notebook with alterations in attribute names for functionality.